### PR TITLE
Fix all REVIEW.md warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ y esta disenada para integrarse con una **aplicacion web en Angular** para admin
 - **API REST completa** con CRUD para todos los recursos del dominio
 - **Arquitectura en capas** (Routes -> Controllers -> Services -> Repositories)
 - **Base de datos PostgreSQL** con pool de conexiones (max 20)
-- **Tests de integracion** con Jest y Supertest (8 archivos de test)
+- **Tests de integracion** con Jest y Supertest (9 archivos de test)
 - **Seguridad** con Helmet, CORS y Rate Limiting (100 req/15min)
 - **Autenticacion JWT** para proteger los endpoints de administracion (login, token Bearer)
 - **Manejo de errores** centralizado con clases personalizadas (ValidationError, NotFoundError, DuplicateError, BusinessRuleError, UnauthorizedError)
@@ -138,6 +138,7 @@ yum-now-api/
 │   ├── customers.js
 │   ├── order-items.js
 │   ├── orders.js
+│   ├── payments.js
 │   └── products.js
 │
 ├── controllers/              # Manejo de requests/responses HTTP
@@ -149,6 +150,7 @@ yum-now-api/
 │   ├── customer-preferences-controller.js
 │   ├── order-items-controller.js
 │   ├── orders-controller.js
+│   ├── payments-controller.js
 │   └── products-controller.js
 │
 ├── services/                 # Logica de negocio y validacion
@@ -160,6 +162,7 @@ yum-now-api/
 │   ├── customer-preferences-service.js
 │   ├── orders-items-service.js
 │   ├── orders-service.js
+│   ├── payments-service.js
 │   └── product-service.js
 │
 ├── repositories/             # Capa de persistencia (queries SQL)
@@ -170,10 +173,14 @@ yum-now-api/
 │   ├── customer-preferences-repository.js
 │   ├── order-items-repository.js
 │   ├── orders-repository.js
+│   ├── payments-repository.js
 │   └── products-repository.js
 │
 ├── middleware/               # Middlewares personalizados
 │   └── authenticate.js       # Verificacion de token JWT
+│
+├── utils/                    # Utilidades compartidas
+│   └── sanitize.js           # Sanitizacion de inputs y parseo de paginacion
 │
 ├── errors/                   # Clases de error personalizadas
 │   └── custom-errors.js
@@ -188,6 +195,7 @@ yum-now-api/
 │   ├── customers.test.js
 │   ├── orderItems.test.js
 │   ├── orders.test.js
+│   ├── payments.test.js
 │   └── products.test.js
 │
 ├── .env.example              # Plantilla de variables de entorno
@@ -377,6 +385,17 @@ ADMIN_PASSWORD=tu-password-seguro
 | PUT | `/api/customer-preferences/:id` | Actualizar preferencia |
 | DELETE | `/api/customer-preferences/:id` | Eliminar preferencia |
 
+### Pagos (`/api/payments`)
+| Metodo | Ruta | Auth | Descripcion |
+|--------|------|------|-------------|
+| POST | `/api/payments` | No | Registrar pago (usado por el bot) |
+| PATCH | `/api/payments/order/:order_id/receipt` | No | Actualizar comprobante de pago |
+| GET | `/api/payments` | **Si** | Listar todos los pagos (paginacion: ?limit=&offset=) |
+| GET | `/api/payments/status/:status` | **Si** | Pagos por estado (pending, verified, rejected) |
+| GET | `/api/payments/order/:order_id` | **Si** | Obtener pago por ID de orden |
+| PATCH | `/api/payments/order/:order_id/verify` | **Si** | Verificar o rechazar un pago |
+| PATCH | `/api/payments/order/:order_id/amount` | **Si** | Actualizar monto reportado |
+
 ### Health Check
 | Metodo | Ruta | Descripcion |
 |--------|------|-------------|
@@ -458,6 +477,7 @@ npm test
 - **Rate Limiting**: 100 requests por IP cada 15 minutos en rutas `/api/*`
 - **JWT authenticate**: Verifica token Bearer en endpoints de administracion
 - **Body Parsing**: JSON y URL-encoded via Express built-in
+- **Sanitizacion de inputs**: Limpieza de caracteres especiales en mensajes de error y validacion de parametros de paginacion (`utils/sanitize.js`)
 
 ---
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,416 +1,263 @@
 # Code Review – Yum Now API
 
-**Date:** 2026-03-11
+**Date:** 2026-03-28
 **Reviewed by:** code-reviewer agent
-**Scope:** Full project — all `.js` files excluding `node_modules`
+**Scope:** Full project — 54 files reviewed
 
 ---
 
 ## Summary
 
-The project maintains a solid and consistent layered architecture. Controllers are thin, services contain business logic, repositories are properly isolated, and all SQL uses parameterized queries with field whitelists in `updatePartial` methods — no SQL injection risk. All 264 tests pass. Error handling is correct: `DuplicateError → 409`, `NotFoundError → 404`, `ValidationError → 400`. The `ordersService` now throws `NotFoundError` correctly for missing customer/address records.
-
-Since the last review (2026-03-06), the following issues were resolved: `DuplicateError → 409` corrected in `assignOrdersController.js`, Spanish JSON key `preferencia` fixed in `customerPreferencesController.js`, `NotFoundError` used correctly in `ordersService.js`, `CustomerService.js` renamed to `customer-service.js`, business logic moved from `couriersController` to `couriersService`, global error handler hardened in `app.js`, phone validation message corrected in `couriersService.js`, and Spanish comments removed from all route files and most service files.
-
-Remaining issues are concentrated in: SSL security in production, Spanish `console.error` messages across all controllers, Spanish JSDoc in `assignOrdersRepository.js`, a Spanish comment in `productsController.js`, Spanish messages in `test-connection.js`, an unreferenced root-level utility file, duplicated SQL JOIN blocks, and functions that exceed the 20-line limit.
+The project has a solid layered architecture (Routes → Controllers → Services → Repositories) with consistent use of custom error classes, parameterized SQL queries, JWT authentication, and good test coverage via Jest/Supertest. The payments module added recently is well-structured and follows existing conventions. The main areas to address are: inconsistent PostgreSQL schema name casing across repositories, missing `offset` pagination in two repositories, an unused import, and English-only violations in test descriptions and one comment.
 
 ---
 
 ## Critical Issues 🔴
 
-### 1. `rejectUnauthorized: false` in production SSL config
-**File:** `db.js:31`
+### 1. Inconsistent PostgreSQL schema name casing across repositories
 
-Disabling SSL certificate verification in production exposes the database connection to man-in-the-middle attacks. The current code silently accepts any certificate, including forged ones.
+PostgreSQL schema names are case-sensitive when double-quoted at creation time. Half the repositories use `YuNowDataBase` while the other half use `yunowdatabase`. If the schema was created with quotes (`"YuNowDataBase"`), the lowercase references will fail at runtime.
+
+| File | Schema used |
+|------|------------|
+| `repositories/products-repository.js` | `YuNowDataBase` |
+| `repositories/customer-repository.js` | `YuNowDataBase` |
+| `repositories/addresses-repository.js` | `YuNowDataBase` |
+| `repositories/couriers-repository.js` | `YuNowDataBase` |
+| `repositories/assign-orders-repository.js` | `YuNowDataBase` |
+| `repositories/customer-preferences-repository.js` | `YuNowDataBase` |
+| `repositories/orders-repository.js` | `yunowdatabase` |
+| `repositories/order-items-repository.js` | `yunowdatabase` |
+| `repositories/payments-repository.js` | `yunowdatabase` |
+
+**Fix:** Standardize to a single casing throughout. If the schema was created unquoted (lowercase in PostgreSQL), use `yunowdatabase` everywhere. Centralize the schema name in a single constant to prevent future drift:
 
 ```js
-// ❌ Current
-if (process.env.NODE_ENV === 'production') {
-  poolConfig.ssl = { rejectUnauthorized: false };
-}
+// db.js or a shared config file
+const SCHEMA = 'yunowdatabase';
+module.exports = { SCHEMA };
 
-// ✅ Fix — use a proper CA certificate supplied via env variable
-if (process.env.NODE_ENV === 'production') {
-  poolConfig.ssl = {
-    rejectUnauthorized: true,
-    ca: process.env.DB_SSL_CA
-  };
-}
+// In each repository:
+const { SCHEMA } = require('../db');
+this.tableName = `${SCHEMA}.orders`;
 ```
-
-Add `DB_SSL_CA` to `.env.example` and provision the certificate in the deployment environment.
 
 ---
 
 ## Warnings 🟡
 
-### 2. Spanish `console.error` messages throughout all controllers
+### 2. `BusinessRuleError` imported but never used — `services/assign-orders-service.js:6`
 
-CLAUDE.md mandates **all code in English**, including `console.log` and `console.error` calls. Every controller in the project uses Spanish log messages.
-
-**`controllers/addressesController.js`** (lines 22, 36, 54, 72, 93, 114, 136, 154):
 ```js
-// ❌
-console.error('Error al crear la dirección:', error);
-console.error('Error al obtener las direcciones:', error);
-console.error('Error al obtener las direcciones del cliente:', error);
-// ✅
-console.error('Error creating address:', error);
-console.error('Error fetching addresses:', error);
-console.error('Error fetching addresses by customer:', error);
+// Current
+const {
+  ValidationError,
+  NotFoundError,
+  DuplicateError,
+  BusinessRuleError,   // ← never thrown in this file
+} = require("../errors/custom-errors");
 ```
 
-**`controllers/ordersController.js`** (lines 12, 32, 49, 63, 80, 97, 118, 140, 162, 178):
-```js
-// ❌
-console.error("Error al crear la orden:", err.message);
-console.error("Error al obtener las órdenes:", err.message);
-// ✅
-console.error("Error creating order:", err.message);
-console.error("Error fetching orders:", err.message);
-```
-
-**`controllers/customerController.js`** (lines 12, 31, 41, 60, 78, 104, 130):
-```js
-// ❌
-console.error('Error al crear cliente:', err.message);
-console.error('Error al buscar cliente: ', err.message);
-// ✅
-console.error('Error creating customer:', err.message);
-console.error('Error fetching customer by phone:', err.message);
-```
-
-**`controllers/productsController.js`** (lines 20, 44, 60, 81, 107, 136, 166, 188):
-```js
-// ❌
-console.error("Error al crear producto:", err.message);
-console.error("Error al obtener productos:", err.message);
-// ✅
-console.error("Error creating product:", err.message);
-console.error("Error fetching products:", err.message);
-```
-
-Same pattern applies to `couriersController.js`, `assignOrdersController.js`, `customerPreferencesController.js`, and `orderItemsController.js`.
-
----
-
-### 3. Spanish comment in `productsController.js`
-**File:** `controllers/productsController.js:46`
+**Fix:** Remove the unused import.
 
 ```js
-// ❌
-// ✅ AGREGADO: Manejo de ValidationError para límites inválidos
-
-// ✅ Fix
-// Added: ValidationError handling for invalid pagination limits
+const { ValidationError, NotFoundError, DuplicateError } = require("../errors/custom-errors");
 ```
 
 ---
 
-### 4. Spanish JSDoc comments in `assignOrdersRepository.js`
-**File:** `repositories/assignOrdersRepository.js` — all JSDoc blocks (lines 11–15, 29–31, 64–66, 101–103, 138–140, 152–154, 163–165, 174–177, 191–193, 206–208)
+### 3. `getAll()` missing `offset` parameter — `repositories/customer-repository.js:12` and `repositories/addresses-repository.js:12`
+
+Both repositories only accept `limit`, breaking consistent pagination across the API.
+
+`customer-repository.js:12`:
+```js
+async getAll(limit) {  // ← no offset
+    const result = await db.query(
+        'SELECT ... FROM YuNowDataBase.customers ORDER BY id ASC LIMIT $1',
+        [limit]
+    );
+```
+
+`addresses-repository.js:12`:
+```js
+async getAll(limit) {  // ← no offset
+    const result = await db.query('SELECT * FROM YuNowDataBase.addresses ORDER BY id ASC LIMIT $1', [limit]);
+```
+
+**Fix:** Add `offset = 0` parameter and `OFFSET $2` to both queries, matching all other repositories.
+
+---
+
+### 4. `assign-orders-repository.js:58` — `getAll()` has no pagination at all
 
 ```js
-// ❌ Current
-/**
- * Crear una nueva asignación de orden a un courier
- * @param {Object} assignData - Datos de la asignación
- * @param {number} assignData.order_id - ID de la orden
- * @returns {Object} Asignación creada
- */
-
-// ✅ Fix
-/**
- * Creates a new order-to-courier assignment
- * @param {Object} assignData - Assignment data
- * @param {number} assignData.order_id - Order ID
- * @returns {Object} Created assignment
- */
-```
-
-All JSDoc blocks in this file must be translated to English.
-
----
-
-### 5. Spanish console messages in `test-connection.js`
-**File:** `test-connection.js:6,8`
-
-```js
-// ❌
-console.log("✅ Conectado a Supabase:", res.rows[0]);
-console.error("❌ Error de conexión:", err);
-
-// ✅
-console.log("Connected to database:", res.rows[0]);
-console.error("Connection error:", err);
-```
-
----
-
-### 6. File naming convention — camelCase instead of kebab-case
-**Files:** Most service, controller, repository, and route files
-
-CLAUDE.md requires kebab-case file names. `customer-service.js` is the only file that follows this rule. All other files use camelCase. This causes cross-platform failures on Linux (Docker, CI/CD, production servers) if `require` paths differ in casing.
-
-Key targets for migration:
-```
-services/ordersService.js              → orders-service.js
-services/couriersService.js            → couriers-service.js
-services/addressesService.js           → addresses-service.js
-services/productService.js             → product-service.js
-services/ordersItemsService.js         → orders-items-service.js
-services/customerPreferencesService.js → customer-preferences-service.js
-services/assignOrdersService.js        → assign-orders-service.js
-controllers/ordersController.js        → orders-controller.js
-controllers/customerController.js      → customer-controller.js
-(and all other controllers/repositories/routes)
-```
-
----
-
-### 7. `validateOrderData` far exceeds 20-line limit
-**File:** `services/ordersService.js:7–83` (77 lines)
-
-CLAUDE.md requires functions under 20 lines with a single responsibility.
-
-```js
-// ❌ One 77-line method doing 5 different validations
-async validateOrderData(orderData, isPartial = false, isCreate = false) { ... }
-
-// ✅ Extract into focused helpers
-validateCustomerId(customer_id) { ... }         // ~8 lines
-validateAddressId(address_id) { ... }           // ~8 lines
-async resolveCustomer(customer_id) { ... }      // ~6 lines
-async resolveAddress(address_id) { ... }        // ~6 lines
-validateAddressBelongsToCustomer(...) { ... }   // ~5 lines
-```
-
----
-
-### 8. `validateProductData` far exceeds 20-line limit
-**File:** `services/productService.js:5–64` (60 lines)
-
-```js
-// ❌ One 60-line method
-validateProductData(name, description, price, is_active, isPartial = false) { ... }
-
-// ✅ Extract
-validateName(name, isPartial) { ... }
-validateDescription(description) { ... }
-validatePrice(price, isPartial) { ... }
-```
-
----
-
-### 9. `validateCourierData` exceeds 20-line limit
-**File:** `services/couriersService.js:5–64` (60 lines)
-
-Same issue as above — break into `validateName`, `validatePhone`, `validateVehicle`, `validateLicensePlate`.
-
----
-
-### 10. `validateAddressData` exceeds 20-line limit
-**File:** `services/addressesService.js:6` (approx. 55 lines)
-
-Same pattern — extract individual field validators.
-
----
-
-### 11. Duplicated SQL JOIN block in `assignOrdersRepository.js`
-**File:** `repositories/assignOrdersRepository.js:33–134`
-
-The same 26-line `SELECT … JOIN` block is copy-pasted identically across `getAll()`, `getByCourierId()`, and `getByOrderId()`. Any future schema change must be applied in three places.
-
-```js
-// ✅ Fix — extract base query
-const BASE_ASSIGNMENT_QUERY = `
-  SELECT
-    ao.id AS assignment_id, ao.assigned_at,
-    c.id AS courier_id, c.name AS courier_name, ...
-  FROM YuNowDataBase.assignment_order ao
-  INNER JOIN YuNowDataBase.couriers c ON ao.courier_id = c.id
-  INNER JOIN YuNowDataBase.orders o ON ao.order_id = o.id
-  LEFT JOIN YuNowDataBase.order_statuses os ON o.status_id = os.id
-  ...
-`;
-
 async getAll() {
-  const result = await db.query(`${BASE_ASSIGNMENT_QUERY} ORDER BY ao.assigned_at DESC`);
-  return result.rows;
-}
+    const query = `${BASE_ASSIGNMENT_QUERY} ORDER BY ao.assigned_at DESC`;
+    // ← no LIMIT / OFFSET
+```
 
-async getByCourierId(courier_id) {
-  const result = await db.query(
-    `${BASE_ASSIGNMENT_QUERY} WHERE ao.courier_id = $1 ORDER BY ao.assigned_at DESC`,
-    [courier_id]
-  );
-  return result.rows;
-}
+As the dataset grows this query returns every row. **Fix:** Add `limit = 100, offset = 0` parameters and `LIMIT $1 OFFSET $2`.
+
+---
+
+### 5. Commented-out code left in production file — `app.js:85`
+
+```js
+//console.log("DB host:", process.env.DB_HOST);
+```
+
+Dead code should not live in production files. **Fix:** Remove the commented line.
+
+---
+
+### 6. English-only violation — test description strings in Spanish
+
+All `it()` / `describe()` descriptions in the test files are written in Spanish, violating the English-only rule for code.
+
+Examples from `test/payments.test.js`:
+```js
+it("Deberia crear un pago digital exitosamente", ...)       // line 16
+it("Deberia devolver error cuando order_id es invalido", ...)  // line 125
+```
+
+Comment in Spanish from `test/setupTests.js:13`:
+```js
+// Silencia todos los console.error en los tests
+```
+
+**Fix:** Write all `describe()`/`it()` strings and inline comments in English:
+```js
+it("should create a digital payment successfully", ...)
+it("should return error when order_id is invalid", ...)
+
+// Silence all console.error calls in tests
 ```
 
 ---
 
-### 12. `test-connection.js` at project root — unreferenced utility
-**File:** `test-connection.js`
+### 7. Inconsistent validation pattern in `services/orders-service.js:44`
 
-This file exists at the root but is not referenced in any test suite or npm script. If it's a one-time utility, remove it. If needed, move it to `test/` and add an npm script.
+`validateTotal` returns a string or `null` instead of throwing, unlike all other validators in the project which throw directly.
 
----
+```js
+// Current — inconsistent
+validateTotal(total) {
+    if (total !== undefined && (isNaN(total) || parseFloat(total) < 0)) {
+      return "El total no puede ser negativo";  // ← returns string
+    }
+    return null;
+}
 
-### 13. API error response format inconsistent with CLAUDE.md spec
-**Files:** All controllers
-
-CLAUDE.md specifies:
-```json
-{ "error": "ValidationError", "message": "El teléfono es obligatorio" }
+// All other validators do this:
+validateId(id) {
+    if (!id || isNaN(id) || parseInt(id) <= 0) {
+        throw new ValidationError('ID inválido');  // ← throws directly
+    }
+}
 ```
 
-All controllers currently return:
-```json
-{ "error": "El teléfono es obligatorio" }
-```
-
-The error type name is absent, making client-side error handling harder and contradicting the documented contract. This requires updating both controllers and tests simultaneously.
+This forces callers to check the return value, increasing cognitive load. **Fix:** Either throw directly or document the return-value pattern explicitly and apply it consistently.
 
 ---
 
 ## Suggestions 🟢
 
-### 14. Extract error handling to shared middleware
-**Files:** All controllers
+### 8. `CLAUDE.md` does not exist in the repository
 
-The `catch` block pattern is repeated in every controller function (8 controllers × ~5 functions = ~40 identical blocks). A reusable error handler would eliminate this duplication:
-
-```js
-// middleware/errorHandler.js
-const handleControllerError = (err, res, fallbackMessage = 'Error interno del servidor') => {
-  if (err instanceof ValidationError) return res.status(400).json({ error: err.message });
-  if (err instanceof NotFoundError)   return res.status(404).json({ error: err.message });
-  if (err instanceof DuplicateError)  return res.status(409).json({ error: err.message });
-  if (err instanceof BusinessRuleError) return res.status(422).json({ error: err.message });
-  console.error(err);
-  return res.status(500).json({ error: fallbackMessage });
-};
-```
+The project references a `CLAUDE.md` with architecture and coding rules, but the file is missing. **Fix:** Create the file with the agreed-upon rules so all contributors can reference them.
 
 ---
 
-### 15. Missing `BusinessRuleError` handling in controllers
-**Files:** `controllers/ordersController.js`, `controllers/addressesController.js`, others
-
-`BusinessRuleError` is defined in `customErrors.js` and mapped to 422, but no controller currently catches it. If a service ever throws one, it falls through to 500.
+### 9. `auth-service.js:27` — timing-safe compare short-circuits on length mismatch
 
 ```js
-// Add to catch blocks
-if (err instanceof BusinessRuleError) {
-  return res.status(422).json({ error: err.message });
+function timingSafeCompare(a, b) {
+  const bufA = Buffer.from(String(a));
+  const bufB = Buffer.from(String(b));
+
+  if (bufA.length !== bufB.length) return false;  // ← early return reveals expected length
+
+  return crypto.timingSafeEqual(bufA, bufB);
 }
 ```
 
----
-
-### 16. Redundant partial update for orders
-**File:** `services/ordersService.js:162–188`, `routes/orders.js:13`
-
-`updateOrderPartial` (`PATCH /:id`) only accepts `status_id`, making it functionally identical to `updateStatusOrder` (`PATCH /:id/status`). Consider removing one endpoint or expanding `updateOrderPartial` to support additional mutable fields.
+The early-exit on length mismatch is measurably faster than the full comparison, allowing a timing attacker to enumerate the expected credential length. For a single-admin system this is low risk, but a constant-time approach is preferred (e.g., pad both buffers to the same length before comparison).
 
 ---
 
-### 17. `validateAddressData` has 8 positional parameters
-**File:** `services/addressesService.js:6`
+### 10. `products-repository.js:43` — `SELECT *` in dynamic filter query
 
 ```js
-// ❌ 8 positional parameters — error-prone
-validateAddressData(customer_id, label, address_text, reference, latitude, longitude, is_primary, isPartial)
-
-// ✅ Accept an object and destructure
-validateAddressData(addressData, isPartial = false) {
-  const { customer_id, label, address_text, reference, latitude, longitude, is_primary } = addressData;
-}
+let query = `SELECT * FROM ${this.tableName} WHERE 1=1`;
 ```
+
+Prefer an explicit column list to avoid returning unintended fields if the schema changes.
 
 ---
 
-### 18. Dead code in `normalizeProductData`
-**File:** `services/productService.js:146–148`
+### 11. No tests verify that protected routes reject unauthenticated requests
 
-Inside `if (is_active !== undefined)`, the inner check `if (is_active === undefined || ...)` can never be true — it's unreachable dead code:
-
-```js
-// ❌ Inner check is dead code — outer guard already prevents is_active === undefined
-if (is_active !== undefined) {
-  if (is_active === undefined || is_active === null || is_active === '') { // always false
-    normalized.is_active = false;
-  }
-```
-
-Remove the dead inner condition. The `else` branch at line 157 covers the default case correctly.
+`test/setupTests.js` globally mocks the `authenticate` middleware, which means no test confirms that a real request without a token receives a `401`. Consider adding at least one test per protected route group without the mock to validate the auth middleware itself.
 
 ---
 
-### 19. Service-level unit tests are missing
-**Files:** All `test/*.test.js`
+### 12. `orders-items-service.js` — `updateQuantityOrderItem` and `updatePriceOrderItem` are unreachable from the controller
 
-All tests mock either the service or repository layer and test through the HTTP controller. There are no isolated unit tests for complex service validation logic (e.g., `validateOrderData`, `validateProductData`). Consider adding service-level tests for edge cases.
+`controllers/order-items-controller.js` only calls `updateOrderItem`. The standalone `updateQuantityOrderItem` and `updatePriceOrderItem` methods in the service are dead code.
 
 ---
 
 ## CLAUDE.md Violations
 
-| Rule | Violation | File(s) | Severity |
-|------|-----------|---------|----------|
-| SSL secure in production | `rejectUnauthorized: false` | `db.js:31` | 🔴 Critical |
-| Comments/logs in English | Spanish `console.error` in all controllers | All `controllers/*.js` | 🟡 Warning |
-| Comments in English | Spanish comment `// ✅ AGREGADO:` | `productsController.js:46` | 🟡 Warning |
-| Comments in English | Spanish JSDoc throughout | `assignOrdersRepository.js` | 🟡 Warning |
-| Comments/logs in English | Spanish `console.log/error` | `test-connection.js:6,8` | 🟡 Warning |
-| Files: kebab-case | camelCase file names across entire codebase | All files except `customer-service.js` | 🟡 Warning |
-| Functions ≤ 20 lines | `validateOrderData` is 77 lines | `ordersService.js:7` | 🟡 Warning |
-| Functions ≤ 20 lines | `validateProductData` is 60 lines | `productService.js:5` | 🟡 Warning |
-| Functions ≤ 20 lines | `validateCourierData` is 60 lines | `couriersService.js:5` | 🟡 Warning |
-| Functions ≤ 20 lines | `validateAddressData` is ~55 lines | `addressesService.js:6` | 🟡 Warning |
-| No duplicated code | SQL JOIN block duplicated 3× | `assignOrdersRepository.js` | 🟡 Warning |
+> Note: `CLAUDE.md` was not found in the repository. The violations below are assessed against the rules defined in the `code-reviewer` command.
+
+| Rule | Violation | Location |
+|------|-----------|----------|
+| English-only code | `it()` descriptions in Spanish | All test files |
+| English-only code | Comment in Spanish (`// Silencia todos…`) | `test/setupTests.js:13` |
+| No dead code | Commented-out `console.log` | `app.js:85` |
+| Consistent naming | Schema casing `YuNowDataBase` vs `yunowdatabase` | 9 repository files |
+| No unused imports | `BusinessRuleError` imported but unused | `services/assign-orders-service.js:6` |
 
 ---
 
 ## Checklist Summary
 
-| Area | Item | Status |
-|------|------|--------|
-| **Architecture** | Layered architecture respected | ✅ Pass |
+| Category | Item | Status |
+|----------|------|--------|
+| **Architecture** | Layered architecture respected (Routes → Controllers → Services → Repositories) | ✅ Pass |
 | **Architecture** | Controllers contain no business logic | ✅ Pass |
-| **Architecture** | Services contain no Express objects | ✅ Pass |
+| **Architecture** | Services contain no Express objects (req, res) | ✅ Pass |
 | **Architecture** | Repositories contain only SQL | ✅ Pass |
-| **Architecture** | Services use repositories (no direct `db.query`) | ✅ Pass |
-| **Language** | Variable/function names in English | ✅ Pass |
-| **Language** | File names in English | ✅ Pass |
-| **Language** | Comments in English | ❌ Fail — Spanish JSDoc in `assignOrdersRepository.js`; Spanish comment in `productsController.js:46` |
-| **Language** | `console.log/error` in English | ❌ Fail — Spanish messages in all controllers and `test-connection.js` |
+| **Architecture** | Services never call `db.query()` directly | ✅ Pass |
+| **Language** | Variable and function names in English | ✅ Pass |
+| **Language** | File names in English (kebab-case) | ✅ Pass |
+| **Language** | Inline comments in English | ⚠️ Partial — one comment in Spanish (`setupTests.js:13`) |
+| **Language** | `console.log()` messages in English | ✅ Pass |
 | **Language** | JSON response keys in English | ✅ Pass |
-| **Language** | User-facing error strings in Spanish | ✅ Pass |
-| **Naming** | Variables/functions: camelCase | ✅ Pass |
-| **Naming** | Files: kebab-case | ❌ Fail — only `customer-service.js` is kebab-case; all others are camelCase |
-| **Naming** | DB tables/columns: snake_case | ✅ Pass |
+| **Language** | Test descriptions in English | ❌ Fail — all `it()` strings in Spanish |
+| **Naming** | camelCase for variables and functions | ✅ Pass |
+| **Naming** | PascalCase for classes | ✅ Pass |
+| **Naming** | kebab-case for file names | ✅ Pass |
+| **Naming** | UPPER_SNAKE_CASE for constants | ✅ Pass |
 | **Error Handling** | Custom error classes used | ✅ Pass |
-| **Error Handling** | `ValidationError → 400` | ✅ Pass |
-| **Error Handling** | `NotFoundError → 404` | ✅ Pass |
-| **Error Handling** | `DuplicateError → 409` | ✅ Pass |
-| **Error Handling** | `BusinessRuleError → 422` | ⚠️ Partial — no controller catches it |
-| **Error Handling** | `Unknown → 500` with no leak | ✅ Pass |
+| **Error Handling** | ValidationError → 400 | ✅ Pass |
+| **Error Handling** | NotFoundError → 404 | ✅ Pass |
+| **Error Handling** | DuplicateError → 409 | ✅ Pass |
+| **Error Handling** | BusinessRuleError → 422 | ✅ Pass (used in assign-orders-controller) |
 | **Error Handling** | Repositories do not re-wrap errors | ✅ Pass |
-| **Error Handling** | Services translate PG error codes | ✅ Pass |
-| **Security** | Parameterized queries | ✅ Pass |
-| **Security** | Dynamic field names use whitelist | ✅ Pass |
-| **Security** | No exposed secrets | ✅ Pass |
-| **Security** | SSL `rejectUnauthorized` in production | ❌ Fail — `db.js:31` |
+| **Error Handling** | Services translate PostgreSQL error codes | ✅ Pass (23505, 23503 handled) |
+| **Security** | Parameterized queries only | ✅ Pass |
+| **Security** | Dynamic fields use whitelist before SQL injection | ✅ Pass |
+| **Security** | No exposed secrets or API keys | ✅ Pass |
 | **Security** | Input validation on all endpoints | ✅ Pass |
-| **Clean Code** | Functions do one thing | ⚠️ Partial — large validation functions in services |
-| **Clean Code** | Functions under 20 lines | ❌ Fail — `validateOrderData` (77 lines), `validateProductData` (60 lines), `validateCourierData` (60 lines), `validateAddressData` (~55 lines) |
-| **Clean Code** | Descriptive, intention-revealing names | ✅ Pass |
-| **Clean Code** | No duplicated code | ⚠️ Partial — SQL JOIN duplicated 3× in `assignOrdersRepository.js` |
-| **Clean Code** | Early returns preferred | ✅ Pass |
-| **Testing** | Test coverage for endpoints | ✅ Pass |
-| **Testing** | Tests follow Arrange/Act/Assert | ✅ Pass |
-| **Testing** | Service-level unit tests | ⚠️ Partial — tests are primarily integration-level via controllers |
+| **Clean Code** | Functions do one thing | ✅ Pass |
+| **Clean Code** | No duplicated code | ✅ Pass |
+| **Clean Code** | No dead/commented code | ⚠️ Partial — `app.js:85` |
+| **Testing** | Test coverage for endpoints and error handling | ✅ Pass |
+| **Testing** | Tests follow Arrange / Act / Assert | ✅ Pass |
+| **Testing** | Auth middleware tested without mock | ❌ Fail — globally mocked, no negative-path auth tests |
+| **Performance** | Pagination used for large datasets | ⚠️ Partial — `customer-repository`, `addresses-repository`, `assign-orders-repository` missing full pagination |
 | **Performance** | No N+1 query problems | ✅ Pass |
-| **Performance** | Pagination for large datasets | ✅ Pass |
+| **Consistency** | Consistent schema name casing across repositories | ❌ Fail — `YuNowDataBase` vs `yunowdatabase` |

--- a/app.js
+++ b/app.js
@@ -82,6 +82,4 @@ app.use((req, res, next) => {
     res.status(statusCode).json({ error: message });
   });
 
-//console.log("DB host:", process.env.DB_HOST);
-
 module.exports = app;

--- a/controllers/addresses-controller.js
+++ b/controllers/addresses-controller.js
@@ -26,8 +26,7 @@ const addAddress = async (req, res) => {
 
 const getAddresses = async (req, res) => {
     try {
-        const limit = req.query.limit ? parseInt(req.query.limit) : 100;
-        const addresses = await addressesService.getAllAddresses(limit);
+        const addresses = await addressesService.getAllAddresses(req.query.limit, req.query.offset);
         res.json(addresses);
     } catch (error) {
         if (error instanceof ValidationError) {

--- a/controllers/assign-orders-controller.js
+++ b/controllers/assign-orders-controller.js
@@ -29,7 +29,7 @@ const addAssignOrder = async (req, res) => {
 
 const getAssignOrders = async (req, res) => {
   try {
-    const assignments = await assignOrdersService.getAllAssignments();
+    const assignments = await assignOrdersService.getAllAssignments(req.query.limit, req.query.offset);
     res.status(200).json(assignments);
   } catch (err) {
     if (err instanceof NotFoundError) {

--- a/controllers/customer-controller.js
+++ b/controllers/customer-controller.js
@@ -25,7 +25,7 @@ const addCustomer = async (req, res) => {
 
 const getCustomers = async (req, res) => {
     try {
-        const customers = await customerService.getAllCustomers(req.query.limit);
+        const customers = await customerService.getAllCustomers(req.query.limit, req.query.offset);
         res.json(customers);
     } catch (err) {
         console.error('Error fetching customers:', err.message);

--- a/repositories/addresses-repository.js
+++ b/repositories/addresses-repository.js
@@ -9,8 +9,8 @@ class AddressesRepository {
     return result.rows[0];
   };
 
-    async getAll(limit) {
-        const result = await db.query('SELECT * FROM YuNowDataBase.addresses ORDER BY id ASC LIMIT $1', [limit]);
+    async getAll(limit = 100, offset = 0) {
+        const result = await db.query('SELECT * FROM YuNowDataBase.addresses ORDER BY id ASC LIMIT $1 OFFSET $2', [limit, offset]);
         return result.rows;
     };
 

--- a/repositories/assign-orders-repository.js
+++ b/repositories/assign-orders-repository.js
@@ -55,9 +55,9 @@ class AssignOrdersRepository {
    * Gets all assignments with full details
    * @returns {Array} List of assignments with courier and order data
    */
-  async getAll() {
-    const query = `${BASE_ASSIGNMENT_QUERY} ORDER BY ao.assigned_at DESC`;
-    const result = await db.query(query);
+  async getAll(limit = 100, offset = 0) {
+    const query = `${BASE_ASSIGNMENT_QUERY} ORDER BY ao.assigned_at DESC LIMIT $1 OFFSET $2`;
+    const result = await db.query(query, [limit, offset]);
     return result.rows;
   }
 

--- a/repositories/customer-repository.js
+++ b/repositories/customer-repository.js
@@ -9,10 +9,10 @@ class CustomerRepository {
         return result.rows[0];
     };
 
-    async getAll(limit) {
+    async getAll(limit = 100, offset = 0) {
         const result = await db.query(
-            'SELECT id, name, phone, email, created_at FROM YuNowDataBase.customers ORDER BY id ASC LIMIT $1',
-            [limit]
+            'SELECT id, name, phone, email, created_at FROM YuNowDataBase.customers ORDER BY id ASC LIMIT $1 OFFSET $2',
+            [limit, offset]
         );
         return result.rows;
     };

--- a/services/addresses-service.js
+++ b/services/addresses-service.js
@@ -117,9 +117,9 @@ class AddressesService {
             return newAddress;
         };
 
-        async getAllAddresses(limit) {
-            const pagination = parsePagination(limit, 0);
-            const addresses = await addressesRepository.getAll(pagination.limit);
+        async getAllAddresses(limit, offset) {
+            const pagination = parsePagination(limit, offset);
+            const addresses = await addressesRepository.getAll(pagination.limit, pagination.offset);
             return addresses;
         };
 

--- a/services/assign-orders-service.js
+++ b/services/assign-orders-service.js
@@ -3,8 +3,8 @@ const {
   ValidationError,
   NotFoundError,
   DuplicateError,
-  BusinessRuleError,
 } = require("../errors/custom-errors");
+const { parsePagination } = require("../utils/sanitize");
 
 class AssignOrdersService {
   /**
@@ -93,8 +93,9 @@ class AssignOrdersService {
    * @returns {Array} List of assignments
    * @throws {NotFoundError} If no assignments exist
    */
-  async getAllAssignments() {
-    const assignments = await assignOrdersRepository.getAll();
+  async getAllAssignments(limit, offset) {
+    const pagination = parsePagination(limit, offset);
+    const assignments = await assignOrdersRepository.getAll(pagination.limit, pagination.offset);
 
     if (assignments.length === 0) {
       throw new NotFoundError("No hay asignaciones de órdenes disponibles");

--- a/services/customer-service.js
+++ b/services/customer-service.js
@@ -82,9 +82,9 @@ class CustomerService {
         }
     };
 
-    async getAllCustomers(limit) {
-        const pagination = parsePagination(limit, 0);
-        return await customerRepository.getAll(pagination.limit);
+    async getAllCustomers(limit, offset) {
+        const pagination = parsePagination(limit, offset);
+        return await customerRepository.getAll(pagination.limit, pagination.offset);
     };
 
     async getCustomerByPhone(phone) {

--- a/services/orders-service.js
+++ b/services/orders-service.js
@@ -41,13 +41,6 @@ class OrdersService {
     }
   }
 
-  validateTotal(total) {
-    if (total !== undefined && (isNaN(total) || parseFloat(total) < 0)) {
-      return "El total no puede ser negativo";
-    }
-    return null;
-  }
-
   async validatePaymentMethod(payment_method_id) {
     if (!payment_method_id || isNaN(payment_method_id)) {
       return "payment_method_id inválido";
@@ -89,8 +82,9 @@ class OrdersService {
     const { payment_method_id, status_id, total } = orderData;
 
     if (!isCreate && (!isPartial || total !== undefined)) {
-      const totalError = this.validateTotal(total);
-      if (totalError) errors.push(totalError);
+      if (total !== undefined && (isNaN(total) || parseFloat(total) < 0)) {
+        errors.push("El total no puede ser negativo");
+      }
     }
     if (!isPartial || payment_method_id !== undefined) {
       const pmError = await this.validatePaymentMethod(payment_method_id);

--- a/test/addresses.test.js
+++ b/test/addresses.test.js
@@ -9,7 +9,7 @@ describe('POST /api/addresses', () => {
         jest.clearAllMocks();
     });
 
-    it('Debe crear una dirección exitosamente', async () => {
+    it('should create an address successfully', async () => {
         const mockAddress = {
             id: 1,
             customer_id: 1,
@@ -20,9 +20,9 @@ describe('POST /api/addresses', () => {
             longitude: -74.0060,
             is_primary: true
         };
-        
+
         addressesService.addAddress.mockResolvedValueOnce(mockAddress);
-        
+
         const res = await request(app)
             .post('/api/addresses')
             .send({
@@ -34,57 +34,57 @@ describe('POST /api/addresses', () => {
                 longitude: -74.0060,
                 is_primary: true
             });
-        
+
         expect(res.status).toBe(201);
         expect(res.body.message).toBe('Dirección creada exitosamente');
         expect(res.body.address).toEqual(mockAddress);
         expect(addressesService.addAddress).toHaveBeenCalledTimes(1);
     });
 
-    it('Debe fallar si falta customer_id', async () => {
+    it('should fail if customer_id is missing', async () => {
         addressesService.addAddress.mockRejectedValueOnce(
             new ValidationError('ID de cliente inválido')
         );
-        
+
         const res = await request(app)
             .post('/api/addresses')
             .send({ label: 'Casa', address_text: 'Calle 123' });
-        
+
         expect(res.status).toBe(400);
         expect(res.body.error).toBe('ID de cliente inválido');
     });
 
-    it('Debe fallar si falta label', async () => {
+    it('should fail if label is missing', async () => {
         addressesService.addAddress.mockRejectedValueOnce(
             new ValidationError('La etiqueta es obligatoria')
         );
-        
+
         const res = await request(app)
             .post('/api/addresses')
             .send({ customer_id: 1, address_text: 'Calle 123' });
-        
+
         expect(res.status).toBe(400);
         expect(res.body.error).toBe('La etiqueta es obligatoria');
     });
 
-    it('Debe fallar si falta address_text', async () => {
+    it('should fail if address_text is missing', async () => {
         addressesService.addAddress.mockRejectedValueOnce(
             new ValidationError('La dirección es obligatoria')
         );
-        
+
         const res = await request(app)
             .post('/api/addresses')
             .send({ customer_id: 1, label: 'Casa' });
-        
+
         expect(res.status).toBe(400);
         expect(res.body.error).toBe('La dirección es obligatoria');
     });
 
-    it('Debe fallar si el cliente no existe', async () => {
+    it('should fail if customer does not exist', async () => {
         addressesService.addAddress.mockRejectedValueOnce(
             new NotFoundError('Cliente no encontrado')
         );
-        
+
         const res = await request(app)
             .post('/api/addresses')
             .send({
@@ -92,16 +92,16 @@ describe('POST /api/addresses', () => {
                 label: 'Casa',
                 address_text: 'Calle 123'
             });
-        
+
         expect(res.status).toBe(404);
         expect(res.body.error).toBe('Cliente no encontrado');
     });
 
-    it('Debe manejar errores internos del servidor', async () => {
+    it('should handle internal server errors', async () => {
         addressesService.addAddress.mockRejectedValueOnce(
             new Error('Database connection error')
         );
-        
+
         const res = await request(app)
             .post('/api/addresses')
             .send({
@@ -109,7 +109,7 @@ describe('POST /api/addresses', () => {
                 label: 'Casa',
                 address_text: 'Calle 123'
             });
-        
+
         expect(res.status).toBe(500);
         expect(res.body.error).toBe('Error interno del servidor');
     });
@@ -120,41 +120,41 @@ describe('GET /api/addresses', () => {
         jest.clearAllMocks();
     });
 
-    it('Debe obtener todas las direcciones', async () => {
+    it('should get all addresses', async () => {
         const mockAddresses = [
             { id: 1, customer_id: 1, label: 'Casa', address_text: 'Calle 1' },
             { id: 2, customer_id: 2, label: 'Oficina', address_text: 'Calle 2' }
         ];
-        
+
         addressesService.getAllAddresses.mockResolvedValueOnce(mockAddresses);
-        
+
         const res = await request(app).get('/api/addresses');
-        
+
         expect(res.status).toBe(200);
         expect(res.body).toEqual(mockAddresses);
         expect(res.body.length).toBe(2);
     });
 
-    it('Debe obtener direcciones con límite personalizado', async () => {
+    it('should get addresses with custom limit', async () => {
         const mockAddresses = [
             { id: 1, customer_id: 1, label: 'Casa', address_text: 'Calle 1' }
         ];
-        
+
         addressesService.getAllAddresses.mockResolvedValueOnce(mockAddresses);
-        
+
         const res = await request(app).get('/api/addresses?limit=50');
-        
+
         expect(res.status).toBe(200);
-        expect(addressesService.getAllAddresses).toHaveBeenCalledWith(50);
+        expect(addressesService.getAllAddresses).toHaveBeenCalledWith('50', undefined);
     });
 
-    it('Debe fallar con límite inválido', async () => {
+    it('should fail with invalid limit', async () => {
         addressesService.getAllAddresses.mockRejectedValueOnce(
             new ValidationError('El límite debe ser un número positivo')
         );
-        
+
         const res = await request(app).get('/api/addresses?limit=-5');
-        
+
         expect(res.status).toBe(400);
         expect(res.body.error).toBe('El límite debe ser un número positivo');
     });
@@ -165,39 +165,39 @@ describe('GET /api/addresses/customer/:customer_id', () => {
         jest.clearAllMocks();
     });
 
-    it('Debe obtener direcciones por customer_id', async () => {
+    it('should get addresses by customer_id', async () => {
         const mockAddresses = [
             { id: 1, customer_id: 1, label: 'Casa', address_text: 'Calle 1' },
             { id: 2, customer_id: 1, label: 'Oficina', address_text: 'Calle 2' }
         ];
-        
+
         addressesService.getAddressesByCustomerId.mockResolvedValueOnce(mockAddresses);
-        
+
         const res = await request(app).get('/api/addresses/customer/1');
-        
+
         expect(res.status).toBe(200);
         expect(res.body).toEqual(mockAddresses);
         expect(res.body.length).toBe(2);
     });
 
-    it('Debe fallar si no encuentra direcciones del cliente', async () => {
+    it('should fail if no addresses found for customer', async () => {
         addressesService.getAddressesByCustomerId.mockRejectedValueOnce(
             new NotFoundError('No se encontraron direcciones para este cliente')
         );
-        
+
         const res = await request(app).get('/api/addresses/customer/999');
-        
+
         expect(res.status).toBe(404);
         expect(res.body.error).toBe('No se encontraron direcciones para este cliente');
     });
 
-    it('Debe fallar con customer_id inválido', async () => {
+    it('should fail with invalid customer_id', async () => {
         addressesService.getAddressesByCustomerId.mockRejectedValueOnce(
             new ValidationError('ID inválido')
         );
-        
+
         const res = await request(app).get('/api/addresses/customer/abc');
-        
+
         expect(res.status).toBe(400);
         expect(res.body.error).toBe('ID inválido');
     });
@@ -208,7 +208,7 @@ describe('GET /api/addresses/primary/:customer_id', () => {
         jest.clearAllMocks();
     });
 
-    it('Debe obtener la dirección primaria del cliente', async () => {
+    it('should get primary address for customer', async () => {
         const mockAddress = {
             id: 1,
             customer_id: 1,
@@ -216,23 +216,23 @@ describe('GET /api/addresses/primary/:customer_id', () => {
             address_text: 'Calle 1',
             is_primary: true
         };
-        
+
         addressesService.getPrimaryAddressByCustomerId.mockResolvedValueOnce(mockAddress);
-        
+
         const res = await request(app).get('/api/addresses/primary/1');
-        
+
         expect(res.status).toBe(200);
         expect(res.body).toEqual(mockAddress);
         expect(res.body.is_primary).toBe(true);
     });
 
-    it('Debe fallar si no encuentra dirección primaria', async () => {
+    it('should fail if no primary address found', async () => {
         addressesService.getPrimaryAddressByCustomerId.mockRejectedValueOnce(
             new NotFoundError('No se encontró una dirección primaria para este cliente')
         );
-        
+
         const res = await request(app).get('/api/addresses/primary/999');
-        
+
         expect(res.status).toBe(404);
         expect(res.body.error).toContain('dirección primaria');
     });
@@ -243,29 +243,29 @@ describe('GET /api/addresses/:id', () => {
         jest.clearAllMocks();
     });
 
-    it('Debe obtener una dirección por ID', async () => {
+    it('should get an address by ID', async () => {
         const mockAddress = {
             id: 1,
             customer_id: 1,
             label: 'Casa',
             address_text: 'Calle 1'
         };
-        
+
         addressesService.getAddressById.mockResolvedValueOnce(mockAddress);
-        
+
         const res = await request(app).get('/api/addresses/1');
-        
+
         expect(res.status).toBe(200);
         expect(res.body).toEqual(mockAddress);
     });
 
-    it('Debe fallar si no encuentra la dirección', async () => {
+    it('should fail if address not found', async () => {
         addressesService.getAddressById.mockRejectedValueOnce(
             new NotFoundError('Dirección no encontrada')
         );
-        
+
         const res = await request(app).get('/api/addresses/999');
-        
+
         expect(res.status).toBe(404);
         expect(res.body.error).toBe('Dirección no encontrada');
     });
@@ -276,47 +276,47 @@ describe('PATCH /api/addresses/:id', () => {
         jest.clearAllMocks();
     });
 
-    it('Debe actualizar parcialmente una dirección', async () => {
+    it('should partially update an address', async () => {
         const mockUpdatedAddress = {
             id: 1,
             customer_id: 1,
             label: 'Casa Actualizada',
             address_text: 'Calle 1'
         };
-        
+
         addressesService.updateAddressPartial.mockResolvedValueOnce(mockUpdatedAddress);
-        
+
         const res = await request(app)
             .patch('/api/addresses/1')
             .send({ label: 'Casa Actualizada' });
-        
+
         expect(res.status).toBe(200);
         expect(res.body.message).toBe('Dirección actualizada exitosamente');
         expect(res.body.address.label).toBe('Casa Actualizada');
     });
 
-    it('Debe fallar si no encuentra la dirección a actualizar', async () => {
+    it('should fail if address to update is not found', async () => {
         addressesService.updateAddressPartial.mockRejectedValueOnce(
             new NotFoundError('Dirección no encontrada')
         );
-        
+
         const res = await request(app)
             .patch('/api/addresses/999')
             .send({ label: 'Nueva etiqueta' });
-        
+
         expect(res.status).toBe(404);
         expect(res.body.error).toBe('Dirección no encontrada');
     });
 
-    it('Debe fallar con datos inválidos', async () => {
+    it('should fail with invalid data', async () => {
         addressesService.updateAddressPartial.mockRejectedValueOnce(
             new ValidationError('La etiqueta no debe exceder los 50 caracteres')
         );
-        
+
         const res = await request(app)
             .patch('/api/addresses/1')
             .send({ label: 'A'.repeat(51) });
-        
+
         expect(res.status).toBe(400);
         expect(res.body.error).toContain('50 caracteres');
     });
@@ -327,7 +327,7 @@ describe('PUT /api/addresses/:id', () => {
         jest.clearAllMocks();
     });
 
-    it('Debe actualizar completamente una dirección', async () => {
+    it('should fully update an address', async () => {
         const mockUpdatedAddress = {
             id: 1,
             customer_id: 1,
@@ -338,9 +338,9 @@ describe('PUT /api/addresses/:id', () => {
             longitude: -70.2,
             is_primary: false
         };
-        
+
         addressesService.updateAddress.mockResolvedValueOnce(mockUpdatedAddress);
-        
+
         const res = await request(app)
             .put('/api/addresses/1')
             .send({
@@ -352,7 +352,7 @@ describe('PUT /api/addresses/:id', () => {
                 longitude: -70.2,
                 is_primary: false
             });
-        
+
         expect(res.status).toBe(200);
         expect(res.body.message).toBe('Dirección actualizada exitosamente');
         expect(res.body.address).toEqual(mockUpdatedAddress);
@@ -364,41 +364,41 @@ describe('DELETE /api/addresses/:id', () => {
         jest.clearAllMocks();
     });
 
-    it('Debe eliminar una dirección exitosamente', async () => {
+    it('should delete an address successfully', async () => {
         const mockDeletedAddress = {
             id: 1,
             customer_id: 1,
             label: 'Casa',
             address_text: 'Calle 1'
         };
-        
+
         addressesService.deleteAddressById.mockResolvedValueOnce(mockDeletedAddress);
-        
+
         const res = await request(app).delete('/api/addresses/1');
-        
+
         expect(res.status).toBe(200);
         expect(res.body.message).toBe('Dirección eliminada exitosamente');
         expect(res.body.address).toEqual(mockDeletedAddress);
     });
 
-    it('Debe fallar al eliminar dirección primaria', async () => {
+    it('should fail when deleting a primary address', async () => {
         addressesService.deleteAddressById.mockRejectedValueOnce(
             new ValidationError('No se puede eliminar una dirección primaria')
         );
-        
+
         const res = await request(app).delete('/api/addresses/1');
-        
+
         expect(res.status).toBe(400);
         expect(res.body.error).toContain('primaria');
     });
 
-    it('Debe fallar si no encuentra la dirección a eliminar', async () => {
+    it('should fail if address to delete is not found', async () => {
         addressesService.deleteAddressById.mockRejectedValueOnce(
             new NotFoundError('Dirección no encontrada')
         );
-        
+
         const res = await request(app).delete('/api/addresses/999');
-        
+
         expect(res.status).toBe(404);
         expect(res.body.error).toBe('Dirección no encontrada');
     });

--- a/test/assignOrders.test.js
+++ b/test/assignOrders.test.js
@@ -1,4 +1,4 @@
-// Mock del service en lugar del db
+// Mock the service instead of db
 jest.mock('../services/assign-orders-service');
 
 const assignOrdersService = require('../services/assign-orders-service');
@@ -8,14 +8,14 @@ const {
   ValidationError,
   NotFoundError,
   DuplicateError,
-} = require('../errors/custom-errors'); 
+} = require('../errors/custom-errors');
 
 describe('POST /assignOrders', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('Debe crear una asignación de órdenes correctamente', async () => {
+    it('should create an order assignment correctly', async () => {
         assignOrdersService.createAssignment.mockResolvedValue({
             id: 1,
             order_id: 1,
@@ -36,7 +36,7 @@ describe('POST /assignOrders', () => {
         });
     });
 
-    it('Debe retornar 404 si la orden no existe', async () => {
+    it('should return 404 if order does not exist', async () => {
         assignOrdersService.createAssignment.mockRejectedValue(
             new NotFoundError('No existe la orden')
         );
@@ -49,7 +49,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'No existe la orden');
     });
 
-    it('Debe retornar 404 si el repartidor no existe', async () => {
+    it('should return 404 if courier does not exist', async () => {
         assignOrdersService.createAssignment.mockRejectedValue(
             new NotFoundError('Repartidor no encontrado')
         );
@@ -62,7 +62,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'Repartidor no encontrado');
     });
 
-    it('Debe retornar 400 si la asignación ya existe', async () => {
+    it('should return 409 if assignment already exists', async () => {
         assignOrdersService.createAssignment.mockRejectedValue(
             new DuplicateError('La orden ya ha sido asignada a un repartidor')
         );
@@ -75,7 +75,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'La orden ya ha sido asignada a un repartidor');
     });
 
-    it('Debe retornar 500 en caso de error del servidor', async () => {
+    it('should return 500 on server error', async () => {
         assignOrdersService.createAssignment.mockRejectedValue(
             new Error('DB error')
         );
@@ -88,20 +88,20 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'Error interno del servidor');
     });
 
-    it('Debe retornar 400 si faltan parámetros', async () => {
+    it('should return 400 if parameters are missing', async () => {
         assignOrdersService.createAssignment.mockRejectedValue(
             new ValidationError('courier_id es requerido')
         );
 
         const response = await request(app)
             .post('/api/assign-orders')
-            .send({ order_id: 1 }); // Falta courier_id
+            .send({ order_id: 1 }); // courier_id missing
 
         expect(response.status).toBe(400);
         expect(response.body).toHaveProperty('error');
     });
 
-    it('Debe consultar las asignaciones de órdenes correctamente', async () => {
+    it('should fetch all order assignments correctly', async () => {
         assignOrdersService.getAllAssignments.mockResolvedValue([
             {
                 assignment_id: 1,
@@ -125,7 +125,7 @@ describe('POST /assignOrders', () => {
         expect(response.body[0]).toHaveProperty('courier_name', 'Juan Perez');
     });
 
-    it('Debe retornar 500 en caso de error del servidor al consultar asignaciones', async () => {
+    it('should return 500 on server error when fetching assignments', async () => {
         assignOrdersService.getAllAssignments.mockRejectedValue(
             new Error('DB error')
         );
@@ -137,7 +137,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'Error interno del servidor');
     });
 
-    it('Debe retornar 404 si no hay asignaciones de órdenes disponibles', async () => {
+    it('should return 404 if no order assignments available', async () => {
         assignOrdersService.getAllAssignments.mockRejectedValue(
             new NotFoundError('No hay asignaciones de órdenes disponibles.')
         );
@@ -149,7 +149,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'No hay asignaciones de órdenes disponibles.');
     });
 
-    it('Debe consultar las asignaciones de órdenes por ID de repartidor correctamente', async () => {
+    it('should fetch order assignments by courier ID correctly', async () => {
         assignOrdersService.getAssignmentsByCourierId.mockResolvedValue([
             {
                 assignment_id: 1,
@@ -173,7 +173,7 @@ describe('POST /assignOrders', () => {
         expect(response.body[0]).toHaveProperty('courier_name', 'Juan Perez');
     });
 
-    it('Debe retornar 404 si el repartidor no existe al consultar por ID', async () => {
+    it('should return 404 if courier does not exist when fetching by ID', async () => {
         assignOrdersService.getAssignmentsByCourierId.mockRejectedValue(
             new NotFoundError('Repartidor no encontrado')
         );
@@ -185,7 +185,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'Repartidor no encontrado');
     });
 
-    it('Debe retornar 404 si no existe asignación para el repartidor', async () => {
+    it('should return 404 if no assignment exists for courier', async () => {
         assignOrdersService.getAssignmentsByCourierId.mockRejectedValue(
             new NotFoundError('No existe asignación para este repartidor')
         );
@@ -197,7 +197,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'No existe asignación para este repartidor');
     });
 
-    it('Debe retornar 500 en caso de error del servidor al consultar por ID de repartidor', async () => {
+    it('should return 500 on server error when fetching by courier ID', async () => {
         assignOrdersService.getAssignmentsByCourierId.mockRejectedValue(
             new Error('DB error')
         );
@@ -209,7 +209,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'Error interno del servidor');
     });
 
-    it('Debe consultar las asignaciones de órdenes por ID de orden correctamente', async () => {
+    it('should fetch order assignment by order ID correctly', async () => {
         assignOrdersService.getAssignmentByOrderId.mockResolvedValue({
             assignment_id: 1,
             assigned_at: '2024-01-01T00:00:00Z',
@@ -230,7 +230,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('courier_name', 'Juan Perez');
     });
 
-    it('Debe retornar 404 si la orden no existe al consultar por ID', async () => {
+    it('should return 404 if order does not exist when fetching by ID', async () => {
         assignOrdersService.getAssignmentByOrderId.mockRejectedValue(
             new NotFoundError('No existe la orden')
         );
@@ -242,7 +242,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'No existe la orden');
     });
 
-    it('Debe retornar 404 si no existe asignación para la orden', async () => {
+    it('should return 404 if no assignment exists for order', async () => {
         assignOrdersService.getAssignmentByOrderId.mockRejectedValue(
             new NotFoundError('No existe asignación para esta orden')
         );
@@ -254,7 +254,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'No existe asignación para esta orden');
     });
 
-    it('Debe retornar 500 en caso de error del servidor al consultar por ID de orden', async () => {
+    it('should return 500 on server error when fetching by order ID', async () => {
         assignOrdersService.getAssignmentByOrderId.mockRejectedValue(
             new Error('DB error')
         );
@@ -266,7 +266,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'Error interno del servidor');
     });
 
-    it('Debe actualizar la asignación de orden correctamente', async () => {
+    it('should update order assignment correctly', async () => {
         assignOrdersService.updateAssignmentCourier.mockResolvedValue({
             id: 1,
             order_id: 1,
@@ -283,7 +283,7 @@ describe('POST /assignOrders', () => {
         expect(response.body.assignOrder).toEqual({ id: 1, order_id: 1, courier_id: 2 });
     });
 
-    it('Debe retornar 404 si la orden no existe al actualizar', async () => {
+    it('should return 404 if order does not exist when updating', async () => {
         assignOrdersService.updateAssignmentCourier.mockRejectedValue(
             new NotFoundError('No existe la orden')
         );
@@ -296,7 +296,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'No existe la orden');
     });
 
-    it('Debe retornar 404 si el repartidor no existe al actualizar', async () => {
+    it('should return 404 if courier does not exist when updating', async () => {
         assignOrdersService.updateAssignmentCourier.mockRejectedValue(
             new NotFoundError('Repartidor no encontrado')
         );
@@ -309,7 +309,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'Repartidor no encontrado');
     });
 
-    it('Debe retornar 404 si no existe asignación para la orden al actualizar', async () => {
+    it('should return 404 if no assignment exists for order when updating', async () => {
         assignOrdersService.updateAssignmentCourier.mockRejectedValue(
             new NotFoundError('No existe asignación para esta orden')
         );
@@ -322,7 +322,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'No existe asignación para esta orden');
     });
 
-    it('Debe retornar 500 en caso de error del servidor al actualizar', async () => {
+    it('should return 500 on server error when updating', async () => {
         assignOrdersService.updateAssignmentCourier.mockRejectedValue(
             new Error('DB error')
         );
@@ -335,7 +335,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'Error interno del servidor');
     });
 
-    it('Debe eliminar la asignación de orden correctamente', async () => {
+    it('should delete order assignment correctly', async () => {
         assignOrdersService.deleteAssignment.mockResolvedValue({
             id: 1,
             order_id: 1,
@@ -351,7 +351,7 @@ describe('POST /assignOrders', () => {
         expect(response.body.assignOrder).toEqual({ id: 1, order_id: 1, courier_id: 1 });
     });
 
-    it('Debe retornar 404 si la orden no existe al eliminar', async () => {
+    it('should return 404 if order does not exist when deleting', async () => {
         assignOrdersService.deleteAssignment.mockRejectedValue(
             new NotFoundError('No existe la orden')
         );
@@ -363,7 +363,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'No existe la orden');
     });
 
-    it('Debe retornar 404 si no existe asignación para la orden al eliminar', async () => {
+    it('should return 404 if no assignment exists for order when deleting', async () => {
         assignOrdersService.deleteAssignment.mockRejectedValue(
             new NotFoundError('Asignamiento no encontrado')
         );
@@ -375,7 +375,7 @@ describe('POST /assignOrders', () => {
         expect(response.body).toHaveProperty('error', 'Asignamiento no encontrado');
     });
 
-    it('Debe retornar 500 en caso de error del servidor al eliminar', async () => {
+    it('should return 500 on server error when deleting', async () => {
         assignOrdersService.deleteAssignment.mockRejectedValue(
             new Error('DB error')
         );

--- a/test/couriers.test.js
+++ b/test/couriers.test.js
@@ -1,4 +1,4 @@
-// Mock del repository (debe ir ANTES de los requires)
+// Mock repository BEFORE requires
 jest.mock("../repositories/couriers-repository");
 
 const request = require("supertest");
@@ -10,7 +10,7 @@ describe("POST /api/couriers", () => {
     jest.clearAllMocks();
   });
 
-  it("Debe crear un Domiciliario válido", async () => {
+  it("should create a valid courier", async () => {
     const mockCourier = {
       id: 1,
       name: "Juan Pérez",
@@ -42,7 +42,7 @@ describe("POST /api/couriers", () => {
     });
   });
 
-  it("Debe usar available=true por defecto si no se envía", async () => {
+  it("should default available=true when not sent", async () => {
     const mockCourier = {
       id: 1,
       name: "Juan Pérez",
@@ -59,7 +59,7 @@ describe("POST /api/couriers", () => {
       phone: "1234567890",
       vehicle: "Bicicleta",
       license_plate: "ABC123",
-      // available no enviado
+      // available not sent
     });
 
     expect(res.status).toBe(201);
@@ -68,7 +68,7 @@ describe("POST /api/couriers", () => {
     );
   });
 
-  it("Debe rechazar si falta el nombre", async () => {
+  it("should reject if name is missing", async () => {
     const res = await request(app).post("/api/couriers").send({
       phone: "1234567890",
       vehicle: "Bicicleta",
@@ -79,7 +79,7 @@ describe("POST /api/couriers", () => {
     expect(res.body.error).toContain("nombre");
   });
 
-  it("Debe rechazar si falta el teléfono", async () => {
+  it("should reject if phone is missing", async () => {
     const res = await request(app).post("/api/couriers").send({
       name: "Juan Pérez",
       vehicle: "Bicicleta",
@@ -90,7 +90,7 @@ describe("POST /api/couriers", () => {
     expect(res.body.error).toContain("teléfono");
   });
 
-  it("Debe rechazar si falta el vehículo", async () => {
+  it("should reject if vehicle is missing", async () => {
     const res = await request(app).post("/api/couriers").send({
       name: "Juan Pérez",
       phone: "1234567890",
@@ -101,7 +101,7 @@ describe("POST /api/couriers", () => {
     expect(res.body.error).toContain("vehículo");
   });
 
-  it("Debe rechazar si falta la placa", async () => {
+  it("should reject if license_plate is missing", async () => {
     const res = await request(app).post("/api/couriers").send({
       name: "Juan Pérez",
       phone: "1234567890",
@@ -112,7 +112,7 @@ describe("POST /api/couriers", () => {
     expect(res.body.error).toContain("placa");
   });
 
-  it("Debe rechazar si el nombre excede 100 caracteres", async () => {
+  it("should reject if name exceeds 100 characters", async () => {
     const res = await request(app)
       .post("/api/couriers")
       .send({
@@ -126,7 +126,7 @@ describe("POST /api/couriers", () => {
     expect(res.body.error).toContain("100 caracteres");
   });
 
-  it("Debe rechazar si el teléfono excede 20 caracteres", async () => {
+  it("should reject if phone exceeds 20 characters", async () => {
     const res = await request(app)
       .post("/api/couriers")
       .send({
@@ -140,20 +140,20 @@ describe("POST /api/couriers", () => {
     expect(res.body.error).toContain("20 caracteres");
   });
 
-  it("Debe rechazar si available no es booleano", async () => {
+  it("should reject if available is not boolean", async () => {
     const res = await request(app).post("/api/couriers").send({
       name: "Juan Pérez",
       phone: "1234567890",
       vehicle: "Bicicleta",
       license_plate: "ABC123",
-      available: "yes", // String en vez de boolean
+      available: "yes", // string instead of boolean
     });
 
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("booleano");
   });
 
-  it("Debe manejar error de base de datos", async () => {
+  it("should handle database errors", async () => {
     couriersRepository.create.mockRejectedValue(new Error("DB error"));
 
     const res = await request(app).post("/api/couriers").send({
@@ -164,9 +164,7 @@ describe("POST /api/couriers", () => {
     });
 
     expect(res.status).toBe(500);
-    expect(res.body.error).toBe(
-      "Error interno del servidor"
-    );
+    expect(res.body.error).toBe("Error interno del servidor");
   });
 });
 
@@ -175,7 +173,7 @@ describe("GET /api/couriers", () => {
     jest.clearAllMocks();
   });
 
-  it("Debe obtener todos los Domiciliarios con paginación por defecto", async () => {
+  it("should get all couriers with default pagination", async () => {
     const mockCouriers = [
       {
         id: 1,
@@ -205,7 +203,7 @@ describe("GET /api/couriers", () => {
     expect(couriersRepository.getAll).toHaveBeenCalledWith(100, 0);
   });
 
-  it("Debe obtener Domiciliarios con paginación personalizada", async () => {
+  it("should get couriers with custom pagination", async () => {
     couriersRepository.getAll.mockResolvedValue([]);
 
     const res = await request(app)
@@ -216,21 +214,21 @@ describe("GET /api/couriers", () => {
     expect(couriersRepository.getAll).toHaveBeenCalledWith(10, 20);
   });
 
-  it("Debe rechazar límite inválido", async () => {
+  it("should reject invalid limit", async () => {
     const res = await request(app).get("/api/couriers").query({ limit: -5 });
 
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("límite");
   });
 
-  it("Debe rechazar offset inválido", async () => {
+  it("should reject invalid offset", async () => {
     const res = await request(app).get("/api/couriers").query({ offset: -10 });
 
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("offset");
   });
 
-  it("Debe manejar error de base de datos", async () => {
+  it("should handle database errors", async () => {
     couriersRepository.getAll.mockRejectedValue(new Error("DB error"));
 
     const res = await request(app).get("/api/couriers");
@@ -245,7 +243,7 @@ describe("GET /api/couriers/available", () => {
     jest.clearAllMocks();
   });
 
-  it("Debe obtener Domiciliarios disponibles", async () => {
+  it("should get available couriers", async () => {
     const mockCouriers = [
       {
         id: 1,
@@ -267,7 +265,7 @@ describe("GET /api/couriers/available", () => {
     expect(res.body[0].name).toBe("Juan Pérez");
   });
 
-  it("Debe retornar 404 si no hay Domiciliarios disponibles", async () => {
+  it("should return 404 if no couriers available", async () => {
     couriersRepository.getAvailable.mockResolvedValue([]);
 
     const res = await request(app).get("/api/couriers/available");
@@ -276,15 +274,13 @@ describe("GET /api/couriers/available", () => {
     expect(res.body.error).toBe("No hay Domiciliarios disponibles");
   });
 
-  it("Debe manejar error de base de datos", async () => {
+  it("should handle database errors", async () => {
     couriersRepository.getAvailable.mockRejectedValue(new Error("DB error"));
 
     const res = await request(app).get("/api/couriers/available");
 
     expect(res.status).toBe(500);
-    expect(res.body.error).toBe(
-      "Error interno del servidor"
-    );
+    expect(res.body.error).toBe("Error interno del servidor");
   });
 });
 
@@ -293,7 +289,7 @@ describe("GET /api/couriers/filter", () => {
     jest.clearAllMocks();
   });
 
-  it("Debe filtrar Domiciliarios por nombre", async () => {
+  it("should filter couriers by name", async () => {
     const mockCouriers = [
       {
         id: 1,
@@ -321,7 +317,7 @@ describe("GET /api/couriers/filter", () => {
     });
   });
 
-  it("Debe filtrar Domiciliarios por teléfono", async () => {
+  it("should filter couriers by phone", async () => {
     const mockCouriers = [
       {
         id: 2,
@@ -344,7 +340,7 @@ describe("GET /api/couriers/filter", () => {
     expect(res.body[0].phone).toBe("0987654321");
   });
 
-  it("Debe filtrar Domiciliarios por placa", async () => {
+  it("should filter couriers by license plate", async () => {
     const mockCouriers = [
       {
         id: 2,
@@ -367,7 +363,7 @@ describe("GET /api/couriers/filter", () => {
     expect(res.body[0].license_plate).toBe("XYZ789");
   });
 
-  it("Debe retornar 404 si no hay resultados", async () => {
+  it("should return 404 if no results found", async () => {
     couriersRepository.getForFilter.mockResolvedValue([]);
 
     const res = await request(app)
@@ -375,12 +371,10 @@ describe("GET /api/couriers/filter", () => {
       .query({ name: "NoExiste" });
 
     expect(res.status).toBe(404);
-    expect(res.body.error).toBe(
-      "No se encontraron domiciliarios con esos filtros"
-    );
+    expect(res.body.error).toBe("No se encontraron domiciliarios con esos filtros");
   });
 
-  it("Debe manejar error de base de datos", async () => {
+  it("should handle database errors", async () => {
     couriersRepository.getForFilter.mockRejectedValue(new Error("DB error"));
 
     const res = await request(app)
@@ -388,9 +382,7 @@ describe("GET /api/couriers/filter", () => {
       .query({ name: "Juan" });
 
     expect(res.status).toBe(500);
-    expect(res.body.error).toBe(
-      "Error interno del servidor"
-    );
+    expect(res.body.error).toBe("Error interno del servidor");
   });
 });
 
@@ -399,7 +391,7 @@ describe("GET /api/couriers/:id", () => {
     jest.clearAllMocks();
   });
 
-  it("Debe obtener un Domiciliario por ID", async () => {
+  it("should get a courier by ID", async () => {
     const mockCourier = {
       id: 1,
       name: "Juan Pérez",
@@ -418,7 +410,7 @@ describe("GET /api/couriers/:id", () => {
     expect(couriersRepository.getById).toHaveBeenCalledWith("1");
   });
 
-  it("Debe retornar 404 si el Domiciliario no existe", async () => {
+  it("should return 404 if courier does not exist", async () => {
     couriersRepository.getById.mockResolvedValue(null);
 
     const res = await request(app).get("/api/couriers/999");
@@ -427,14 +419,14 @@ describe("GET /api/couriers/:id", () => {
     expect(res.body.error).toBe("Domiciliario no encontrado");
   });
 
-  it("Debe rechazar ID inválido", async () => {
+  it("should reject invalid ID", async () => {
     const res = await request(app).get("/api/couriers/abc");
 
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("ID");
   });
 
-  it("Debe rechazar ID negativo", async () => {
+  it("should reject negative ID", async () => {
     const res = await request(app).get("/api/couriers/-5");
 
     expect(res.status).toBe(400);
@@ -447,7 +439,7 @@ describe("DELETE /api/couriers/:id", () => {
     jest.clearAllMocks();
   });
 
-  it("Debe eliminar un Domiciliario existente", async () => {
+  it("should delete an existing courier", async () => {
     const mockCourier = {
       id: 1,
       name: "Juan Pérez",
@@ -466,7 +458,7 @@ describe("DELETE /api/couriers/:id", () => {
     expect(res.body.courier.id).toBe(1);
   });
 
-  it("Debe retornar 404 si el Domiciliario no existe", async () => {
+  it("should return 404 if courier does not exist", async () => {
     couriersRepository.delete.mockResolvedValue(null);
 
     const res = await request(app).delete("/api/couriers/999");
@@ -475,7 +467,7 @@ describe("DELETE /api/couriers/:id", () => {
     expect(res.body.error).toBe("Domiciliario no encontrado");
   });
 
-  it("Debe manejar error de base de datos", async () => {
+  it("should handle database errors", async () => {
     couriersRepository.delete.mockRejectedValue(new Error("DB error"));
 
     const res = await request(app).delete("/api/couriers/1");
@@ -490,7 +482,7 @@ describe("PUT /api/couriers/:id", () => {
     jest.clearAllMocks();
   });
 
-  it("Debe actualizar un Domiciliario existente", async () => {
+  it("should update an existing courier", async () => {
     const mockUpdated = {
       id: 1,
       name: "Juan Pérez",
@@ -516,7 +508,7 @@ describe("PUT /api/couriers/:id", () => {
     expect(res.body.courier.vehicle).toBe("Moto");
   });
 
-  it("Debe retornar 404 si el Domiciliario no existe", async () => {
+  it("should return 404 if courier does not exist", async () => {
     couriersRepository.update.mockResolvedValue(null);
 
     const res = await request(app).put("/api/couriers/999").send({
@@ -531,17 +523,17 @@ describe("PUT /api/couriers/:id", () => {
     expect(res.body.error).toBe("Domiciliario no encontrado");
   });
 
-  it("Debe rechazar si faltan campos obligatorios", async () => {
+  it("should reject if required fields are missing", async () => {
     const res = await request(app).put("/api/couriers/1").send({
       name: "Juan Pérez",
       phone: "1112223333",
-      // Faltan vehicle y license_plate
+      // vehicle and license_plate missing
     });
 
     expect(res.status).toBe(400);
   });
 
-  it("Debe manejar error de base de datos", async () => {
+  it("should handle database errors", async () => {
     couriersRepository.update.mockRejectedValue(new Error("DB error"));
 
     const res = await request(app).put("/api/couriers/1").send({
@@ -562,7 +554,7 @@ describe("PATCH /api/couriers/:id", () => {
     jest.clearAllMocks();
   });
 
-  it("Debe actualizar parcialmente un Domiciliario", async () => {
+  it("should partially update a courier", async () => {
     const mockUpdated = {
       id: 1,
       name: "Juan Pérez",
@@ -584,7 +576,7 @@ describe("PATCH /api/couriers/:id", () => {
     expect(res.body.courier.available).toBe(false);
   });
 
-  it("Debe actualizar solo un campo", async () => {
+  it("should update a single field", async () => {
     const mockUpdated = {
       id: 1,
       name: "Juan Pérez",
@@ -604,7 +596,7 @@ describe("PATCH /api/couriers/:id", () => {
     expect(res.body.courier.phone).toBe("9999999999");
   });
 
-  it("Debe retornar 404 si el Domiciliario no existe", async () => {
+  it("should return 404 if courier does not exist", async () => {
     couriersRepository.updatePartial.mockResolvedValue(null);
 
     const res = await request(app)
@@ -615,16 +607,16 @@ describe("PATCH /api/couriers/:id", () => {
     expect(res.body.error).toBe("Domiciliario no encontrado");
   });
 
-  it("Debe validar campos enviados", async () => {
+  it("should validate sent fields", async () => {
     const res = await request(app)
       .patch("/api/couriers/1")
-      .send({ phone: "1".repeat(21) }); // Excede límite
+      .send({ phone: "1".repeat(21) }); // exceeds limit
 
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("20 caracteres");
   });
 
-  it("Debe manejar error de base de datos", async () => {
+  it("should handle database errors", async () => {
     couriersRepository.updatePartial.mockRejectedValue(new Error("DB error"));
 
     const res = await request(app)

--- a/test/customerPreferences.test.js
+++ b/test/customerPreferences.test.js
@@ -13,9 +13,9 @@ describe('POST /api/customer-preferences (mock)',()=>{
         db.query.mockReset();
     });
 
-    it('Deberia crear una nueva preferencia de cliente', async () => {
+    it('should create a new customer preference', async () => {
         db.query
-        .mockResolvedValueOnce({ rows: [{ id: 1}] }) // Mock para verificar customer_id
+        .mockResolvedValueOnce({ rows: [{ id: 1}] }) // mock to verify customer_id
         .mockResolvedValueOnce({rows: [{ customer_id: 1, preference_key: 'default_payment_method', preference_value: 'nequi' }]
         });
 
@@ -29,7 +29,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
 
     });
 
-    it('Deberia validar que el customer_id es obligatorio', async () => {
+    it('should validate that customer_id is required', async () => {
         const res = await request(app)
             .post('/api/customer-preferences')
             .send({ preference_key: 'default_payment_method', preference_value: 'nequi' });
@@ -38,7 +38,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toContain('customer_id es obligatorio');
     });
 
-    it('Deberia validar que el customer_id exista en la tabla customers', async () => {
+    it('should validate that customer_id exists in customers table', async () => {
         db.query.mockResolvedValueOnce({ rows: [] });
 
         const res = await request(app)
@@ -49,7 +49,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('No existe un cliente con el customer_id proporcionado');
     });
 
-    it('Deberia manejar errores internos del servidor', async () => {
+    it('should handle internal server errors', async () => {
         db.query.mockRejectedValueOnce(new Error('Error de base de datos'));
 
         const res = await request(app)
@@ -60,7 +60,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('Error interno del servidor');
     });
 
-    it('Deberia validar que preference_key y preference_value son obligatorios', async () => {
+    it('should validate that preference_key and preference_value are required', async () => {
         const res = await request(app)
             .post('/api/customer-preferences')
             .send({ customer_id: 1 });
@@ -70,7 +70,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toContain('preference_value es obligatorio');
     });
 
-    it('Deberia validar que preference_value no este vacio', async () => {
+    it('should validate that preference_value is not empty', async () => {
         const res = await request(app)
             .post('/api/customer-preferences')
             .send({ customer_id: 1, preference_key: 'default_payment_method', preference_value: '' });
@@ -79,7 +79,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toContain('preference_value es obligatorio');
     });
 
-    it('Deberia validar que preference_key no este vacio', async () => {
+    it('should validate that preference_key is not empty', async () => {
         const res = await request(app)
             .post('/api/customer-preferences')
             .send({ customer_id: 1, preference_key: '', preference_value: 'nequi' });
@@ -88,7 +88,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toContain('preference_key es obligatorio');
     });
 
-    it('Deberia obtener todas las preferencias de un cliente', async () => {
+    it('should get all preferences for a customer', async () => {
         db.query
          .mockResolvedValueOnce({ rows: [{ id: 1}] })
         .mockResolvedValueOnce({rows: [
@@ -107,7 +107,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
 
     });
 
-    it('Deberia devolver error cuando no existe el customer_id al obtener preferencias', async () => {
+    it('should return error when customer_id does not exist when fetching preferences', async () => {
         db.query.mockResolvedValueOnce({ rows: [] });
 
         const res = await request(app)
@@ -117,7 +117,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('No existe un cliente con el customer_id proporcionado');
     });
 
-    it('Deberia devolver mensaje cuando el resultado es vacio al obtener preferencias', async () => {
+    it('should return message when result is empty when fetching preferences', async () => {
         db.query
          .mockResolvedValueOnce({ rows: [{ id: 1}] })
         .mockResolvedValueOnce({rows: [] });
@@ -130,7 +130,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.message).toBe('No se encontraron preferencias para este cliente.');
     });
 
-    it('Deberia manejar errores internos del servidor al obtener preferencias', async () => {
+    it('should handle internal server errors when fetching preferences', async () => {
         db.query.mockRejectedValueOnce(new Error('Error de base de datos'));
 
         const res = await request(app)
@@ -140,7 +140,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('Error interno del servidor');
     });
 
-    it('Deberia obtener una preferencia especifica de un cliente', async () => {
+    it('should get a specific preference for a customer', async () => {
         db.query
          .mockResolvedValueOnce({ rows: [{ id: 1}] })
         .mockResolvedValueOnce({rows: [
@@ -156,7 +156,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.preference_value).toBe('nequi');
     });
 
-    it('Deberia devolver error cuando no existe el customer_id al obtener una preferencia especifica', async () => {
+    it('should return error when customer_id does not exist when fetching specific preference', async () => {
         db.query.mockResolvedValueOnce({ rows: [] });
 
         const res = await request(app)
@@ -166,7 +166,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('No existe un cliente con el customer_id proporcionado');
     });
 
-   it('Deberia devolver error cuando no existe la preferencia especifica para el cliente', async () => {
+   it('should return error when specific preference does not exist for customer', async () => {
         db.query
          .mockResolvedValueOnce({ rows: [{ id: 1}] })
         .mockResolvedValueOnce({rows: [] });
@@ -178,7 +178,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('No se encontró la preferencia especificada para este cliente.');
     });
 
-    it('Deberia manejar errores internos del servidor al obtener una preferencia especifica', async () => {
+    it('should handle internal server errors when fetching specific preference', async () => {
         db.query.mockRejectedValueOnce(new Error('Error de base de datos'));
 
         const res = await request(app)
@@ -188,25 +188,25 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('Error interno del servidor');
     });
 
-    it('Deberia validar que preference_key no este vacio al obtener una preferencia especifica', async () => {
+    it('should validate that preference_key is not empty when fetching specific preference', async () => {
         const res = await request(app)
             .get('/api/customer-preferences/customer/1/preference_key/');
 
         expect(res.status).toBe(404); // Because the route won't match
     });
 
-    it('Deberia validar que customer_id no este vacio al obtener una preferencia especifica', async () => {
+    it('should validate that customer_id is not empty when fetching specific preference', async () => {
         const res = await request(app)
             .get('/api/customer-preferences/customer//preference_key/default_payment_method');
 
         expect(res.status).toBe(404); // Because the route won't match
     });
 
-    it('Deberia actualizar una preferencia existente de un cliente', async () => {
+    it('should update an existing customer preference', async () => {
         db.query
-         .mockResolvedValueOnce({ rows: [{ id: 1}] }) // Mock para verificar customer_id
-        .mockResolvedValueOnce({ rows: [{ customer_id: 1, preference_key: 'default_payment_method', preference_value: 'nequi' }] }) // Mock para verificar existencia de preferencia
-        .mockResolvedValueOnce({ rows: [{ customer_id: 1, preference_key: 'default_payment_method', preference_value: 'daviplata' }] }); // Mock para la actualización
+         .mockResolvedValueOnce({ rows: [{ id: 1}] }) // mock to verify customer_id
+        .mockResolvedValueOnce({ rows: [{ customer_id: 1, preference_key: 'default_payment_method', preference_value: 'nequi' }] }) // mock to verify preference exists
+        .mockResolvedValueOnce({ rows: [{ customer_id: 1, preference_key: 'default_payment_method', preference_value: 'daviplata' }] }); // mock for update
 
         const res = await request(app)
             .put('/api/customer-preferences/customer/1/preference_key/default_payment_method')
@@ -217,17 +217,17 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.preference.preference_value).toBe('daviplata');
     });
 
-    it('Debería validar que preference_value es obligatorio al actualizar una preferencia', async () => {
+    it('should validate that preference_value is required when updating a preference', async () => {
     const res = await request(app)
         .put('/api/customer-preferences/customer/1/preference_key/default_payment_method')
-        .send({}); // sin preference_value
+        .send({}); // without preference_value
 
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('Debe proporcionar preference_value');
 });
 
-    it('Debería validar que el customer_id exista en la tabla customers al actualizar una preferencia', async () => {
-        db.query.mockResolvedValueOnce({ rows: [] }); // no existe el customer
+    it('should validate that customer_id exists in customers table when updating a preference', async () => {
+        db.query.mockResolvedValueOnce({ rows: [] }); // customer does not exist
 
         const res = await request(app)
             .put('/api/customer-preferences/customer/999/preference_key/default_payment_method')
@@ -237,7 +237,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('No existe un cliente con el customer_id proporcionado');
     });
 
-    it('Debería validar que preference_value no esté vacío al actualizar una preferencia', async () => {
+    it('should validate that preference_value is not empty when updating a preference', async () => {
         const res = await request(app)
             .put('/api/customer-preferences/customer/1/preference_key/default_payment_method')
             .send({ preference_value: '' });
@@ -246,10 +246,10 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('Debe proporcionar preference_value');
     });
 
-    it('Debería devolver error cuando no existe la preferencia específica para el cliente al actualizar', async () => {
+    it('should return error when specific preference does not exist for customer when updating', async () => {
         db.query
-            .mockResolvedValueOnce({ rows: [{ id: 1 }] }) // mock: customer existe
-            .mockResolvedValueOnce({ rows: [] });         // mock: preferencia no existe
+            .mockResolvedValueOnce({ rows: [{ id: 1 }] }) // mock: customer exists
+            .mockResolvedValueOnce({ rows: [] });         // mock: preference does not exist
 
         const res = await request(app)
             .put('/api/customer-preferences/customer/1/preference_key/non_existent_key')
@@ -259,7 +259,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('No se encontró la preferencia especificada para este cliente.');
     });
 
-    it('Debería manejar errores internos del servidor al actualizar una preferencia', async () => {
+    it('should handle internal server errors when updating a preference', async () => {
         db.query.mockRejectedValueOnce(new Error('Error de base de datos'));
 
         const res = await request(app)
@@ -270,11 +270,11 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('Error interno del servidor');
     });
 
-    it('Deberia eliminar una preferencia existente de un cliente', async () => {
+    it('should delete an existing customer preference', async () => {
         db.query
-         .mockResolvedValueOnce({ rows: [{ id: 1}] }) // Mock para verificar customer_id
-        .mockResolvedValueOnce({ rows: [{ customer_id: 1, preference_key: 'default_payment_method', preference_value: 'nequi' }] }) // Mock para verificar existencia de preferencia
-        .mockResolvedValueOnce({ rows: [] }); // Mock para la eliminación
+         .mockResolvedValueOnce({ rows: [{ id: 1}] }) // mock to verify customer_id
+        .mockResolvedValueOnce({ rows: [{ customer_id: 1, preference_key: 'default_payment_method', preference_value: 'nequi' }] }) // mock to verify preference exists
+        .mockResolvedValueOnce({ rows: [] }); // mock for deletion
 
         const res = await request(app)
             .delete('/api/customer-preferences/customer/1/preference_key/default_payment_method');
@@ -283,7 +283,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.message).toBe('Preferencia eliminada exitosamente.');
     });
 
-    it('Deberia validar que el customer_id exista en la tabla customers al eliminar una preferencia', async () => {
+    it('should validate that customer_id exists in customers table when deleting a preference', async () => {
         db.query.mockResolvedValueOnce({ rows: [] });
 
         const res = await request(app)
@@ -293,10 +293,10 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('No existe un cliente con el customer_id proporcionado');
     });
 
-    it('Deberia devolver error cuando no existe la preferencia especifica para el cliente al eliminar', async () => {
+    it('should return error when specific preference does not exist for customer when deleting', async () => {
         db.query
-         .mockResolvedValueOnce({ rows: [{ id: 1}] }) // Mock para verificar customer_id
-        .mockResolvedValueOnce({ rows: [] }); // Mock para verificar existencia de preferencia
+         .mockResolvedValueOnce({ rows: [{ id: 1}] }) // mock to verify customer_id
+        .mockResolvedValueOnce({ rows: [] }); // mock to verify preference exists
 
         const res = await request(app)
             .delete('/api/customer-preferences/customer/1/preference_key/non_existent_key');
@@ -305,7 +305,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('No se encontró la preferencia especificada para este cliente.');
     });
 
-    it('Deberia manejar errores internos del servidor al eliminar una preferencia', async () => {
+    it('should handle internal server errors when deleting a preference', async () => {
         db.query.mockRejectedValueOnce(new Error('Error de base de datos'));
 
         const res = await request(app)
@@ -315,11 +315,11 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('Error interno del servidor');
     });
 
-    it('Deberia eliminar todas las preferencias de un cliente', async () => {
+    it('should delete all preferences for a customer', async () => {
         db.query
-         .mockResolvedValueOnce({ rows: [{ id: 1}] }) // Mock para verificar customer_id
-        .mockResolvedValueOnce({ rows: [{ customer_id: 1, preference_key: 'default_payment_method', preference_value: 'nequi' }] }) // Mock para verificar existencia de preferencias
-        .mockResolvedValueOnce({ rows: [] }); // Mock para la eliminación
+         .mockResolvedValueOnce({ rows: [{ id: 1}] }) // mock to verify customer_id
+        .mockResolvedValueOnce({ rows: [{ customer_id: 1, preference_key: 'default_payment_method', preference_value: 'nequi' }] }) // mock to verify preferences exist
+        .mockResolvedValueOnce({ rows: [] }); // mock for deletion
 
         const res = await request(app)
             .delete('/api/customer-preferences/customer/1');
@@ -328,7 +328,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.message).toBe('Todas las preferencias del cliente fueron eliminadas exitosamente.');
     });
 
-    it('Deberia validar que el customer_id exista en la tabla customers al eliminar todas las preferencias', async () => {
+    it('should validate that customer_id exists in customers table when deleting all preferences', async () => {
         db.query.mockResolvedValueOnce({ rows: [] });
 
         const res = await request(app)
@@ -338,10 +338,10 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('No existe un cliente con el customer_id proporcionado');
     });
 
-    it('Deberia devolver mensaje cuando no existen preferencias para el cliente al eliminar todas', async () => {
+    it('should return message when no preferences exist for customer when deleting all', async () => {
         db.query
-         .mockResolvedValueOnce({ rows: [{ id: 1}] }) // Mock para verificar customer_id
-        .mockResolvedValueOnce({ rows: [] }); // Mock para verificar existencia de preferencias
+         .mockResolvedValueOnce({ rows: [{ id: 1}] }) // mock to verify customer_id
+        .mockResolvedValueOnce({ rows: [] }); // mock to verify preferences exist
 
         const res = await request(app)
             .delete('/api/customer-preferences/customer/1');
@@ -350,7 +350,7 @@ describe('POST /api/customer-preferences (mock)',()=>{
         expect(res.body.error).toBe('No se encontraron preferencias para este cliente.');
     });
 
-    it('Deberia manejar errores internos del servidor al eliminar todas las preferencias', async () => {
+    it('should handle internal server errors when deleting all preferences', async () => {
         db.query.mockRejectedValueOnce(new Error('Error de base de datos'));
 
         const res = await request(app)

--- a/test/customers.test.js
+++ b/test/customers.test.js
@@ -6,12 +6,12 @@ const customerService = require('../services/customer-service');
 const { ValidationError, NotFoundError, DuplicateError } = require('../errors/custom-errors');
 
 describe('POST /api/customers', () => {
-    
+
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('Debe crear un cliente válido con email', async () => {
+    it('should create a valid customer with email', async () => {
         const mockCustomer = {
             id: 1,
             name: 'Juan Pérez',
@@ -19,9 +19,9 @@ describe('POST /api/customers', () => {
             phone: '1234567890',
             created_at: new Date()
         };
-        
+
         customerService.addCustomer.mockResolvedValueOnce(mockCustomer);
-        
+
         const res = await request(app)
             .post('/api/customers')
             .send({
@@ -36,7 +36,7 @@ describe('POST /api/customers', () => {
         expect(res.body.customer.email).toBe('juan@example.com');
     });
 
-    it('Debe crear un cliente válido SIN email', async () => {
+    it('should create a valid customer WITHOUT email', async () => {
         const mockCustomer = {
             id: 2,
             name: 'María López',
@@ -44,9 +44,9 @@ describe('POST /api/customers', () => {
             phone: '0987654321',
             created_at: new Date()
         };
-        
+
         customerService.addCustomer.mockResolvedValueOnce(mockCustomer);
-        
+
         const res = await request(app)
             .post('/api/customers')
             .send({
@@ -58,7 +58,7 @@ describe('POST /api/customers', () => {
         expect(res.body.customer.email).toBe(null);
     });
 
-    it('Debe fallar si falta el nombre', async () => {
+    it('should fail if name is missing', async () => {
         customerService.addCustomer.mockRejectedValueOnce(
             new ValidationError('Nombre inválido (mínimo 2 caracteres)')
         );
@@ -73,7 +73,7 @@ describe('POST /api/customers', () => {
         expect(res.body.error).toContain('Nombre inválido');
     });
 
-    it('Debe fallar si falta el teléfono', async () => {
+    it('should fail if phone is missing', async () => {
         customerService.addCustomer.mockRejectedValueOnce(
             new ValidationError('Teléfono inválido (mínimo 7 caracteres)')
         );
@@ -88,7 +88,7 @@ describe('POST /api/customers', () => {
         expect(res.body.error).toContain('Teléfono inválido');
     });
 
-    it('Debe fallar si el email es inválido', async () => {
+    it('should fail if email is invalid', async () => {
         customerService.addCustomer.mockRejectedValueOnce(
             new ValidationError('Email inválido')
         );
@@ -105,7 +105,7 @@ describe('POST /api/customers', () => {
         expect(res.body.error).toContain('Email inválido');
     });
 
-    it('Debe fallar si el teléfono ya existe', async () => {
+    it('should fail if phone already exists', async () => {
         customerService.addCustomer.mockRejectedValueOnce(
             new DuplicateError('Ya existe un cliente con ese número de teléfono')
         );
@@ -127,12 +127,12 @@ describe('GET /api/customers', () => {
         jest.clearAllMocks();
     });
 
-    it('Debe consultar clientes', async () => {
+    it('should fetch customers', async () => {
         const mockCustomers = [
             { id: 1, name: 'Juan', email: 'juan@example.com', phone: '1111111111' },
             { id: 2, name: 'María', email: null, phone: '2222222222' }
         ];
-        
+
         customerService.getAllCustomers.mockResolvedValueOnce(mockCustomers);
 
         const res = await request(app).get('/api/customers');
@@ -142,11 +142,11 @@ describe('GET /api/customers', () => {
         expect(res.body[0].name).toBe('Juan');
     });
 
-    it('Debe fallar en la consulta de clientes', async () => {
+    it('should fail fetching customers on DB error', async () => {
         customerService.getAllCustomers.mockRejectedValueOnce(new Error('DB error'));
 
         const res = await request(app).get('/api/customers');
-        
+
         expect(res.status).toBe(500);
         expect(res.body.error).toBe('Error interno del servidor');
     });
@@ -157,14 +157,14 @@ describe('GET /api/customers/phone/:phone', () => {
         jest.clearAllMocks();
     });
 
-    it('Debe consultar cliente por teléfono', async () => {
+    it('should fetch customer by phone', async () => {
         const mockCustomer = {
             id: 1,
             name: 'Juan',
             email: 'juan@example.com',
             phone: '1234567890'
         };
-        
+
         customerService.getCustomerByPhone.mockResolvedValueOnce(mockCustomer);
 
         const res = await request(app).get('/api/customers/phone/1234567890');
@@ -173,7 +173,7 @@ describe('GET /api/customers/phone/:phone', () => {
         expect(res.body.name).toBe('Juan');
     });
 
-    it('Debe fallar si no encuentra cliente por teléfono', async () => {
+    it('should fail if customer not found by phone', async () => {
         customerService.getCustomerByPhone.mockRejectedValueOnce(
             new NotFoundError('Cliente no encontrado')
         );
@@ -184,7 +184,7 @@ describe('GET /api/customers/phone/:phone', () => {
         expect(res.body.error).toBe('Cliente no encontrado');
     });
 
-    it('Debe fallar con teléfono muy corto', async () => {
+    it('should fail with phone too short', async () => {
         customerService.getCustomerByPhone.mockRejectedValueOnce(
             new ValidationError('Teléfono inválido (mínimo 7 caracteres)')
         );
@@ -201,14 +201,14 @@ describe('PUT /api/customers/:id', () => {
         jest.clearAllMocks();
     });
 
-    it('Debe actualizar un cliente completo', async () => {
+    it('should fully update a customer', async () => {
         const mockCustomer = {
             id: 1,
             name: 'Juan Actualizado',
             email: 'nuevo@email.com',
             phone: '0987654321'
         };
-        
+
         customerService.updateCustomer.mockResolvedValueOnce(mockCustomer);
 
         const res = await request(app)
@@ -224,7 +224,7 @@ describe('PUT /api/customers/:id', () => {
         expect(res.body.customer.name).toBe('Juan Actualizado');
     });
 
-    it('Debe fallar si no encuentra cliente para actualizar', async () => {
+    it('should fail if customer not found for update', async () => {
         customerService.updateCustomer.mockRejectedValueOnce(
             new NotFoundError('Cliente no encontrado')
         );
@@ -246,14 +246,14 @@ describe('PATCH /api/customers/:id', () => {
         jest.clearAllMocks();
     });
 
-    it('Debe actualizar cliente parcialmente', async () => {
+    it('should partially update a customer', async () => {
         const mockCustomer = {
             id: 1,
             name: 'Juan',
             email: 'juan@example.com',
             phone: '9999999999'
         };
-        
+
         customerService.updateCustomerPartial.mockResolvedValueOnce(mockCustomer);
 
         const res = await request(app)
@@ -264,7 +264,7 @@ describe('PATCH /api/customers/:id', () => {
         expect(res.body.customer.phone).toBe('9999999999');
     });
 
-    it('Debe fallar si no hay campos para actualizar', async () => {
+    it('should fail if no fields provided for update', async () => {
         customerService.updateCustomerPartial.mockRejectedValueOnce(
             new ValidationError('Debe proporcionar al menos un campo para actualizar')
         );
@@ -283,14 +283,14 @@ describe('DELETE /api/customers/:id', () => {
         jest.clearAllMocks();
     });
 
-    it('Debe eliminar un cliente', async () => {
+    it('should delete a customer', async () => {
         const mockCustomer = {
             id: 1,
             name: 'Juan',
             email: 'juan@example.com',
             phone: '1234567890'
         };
-        
+
         customerService.deleteCustomerById.mockResolvedValueOnce(mockCustomer);
 
         const res = await request(app).delete('/api/customers/1');
@@ -299,7 +299,7 @@ describe('DELETE /api/customers/:id', () => {
         expect(res.body.message).toBe('Cliente eliminado exitosamente');
     });
 
-    it('Debe fallar si no encuentra cliente para eliminar', async () => {
+    it('should fail if customer not found for deletion', async () => {
         customerService.deleteCustomerById.mockRejectedValueOnce(
             new NotFoundError('Cliente no encontrado')
         );
@@ -310,7 +310,7 @@ describe('DELETE /api/customers/:id', () => {
         expect(res.body.error).toBe('Cliente no encontrado');
     });
 
-    it('Debe fallar si cliente tiene órdenes asociadas', async () => {
+    it('should fail if customer has associated orders', async () => {
         customerService.deleteCustomerById.mockRejectedValueOnce(
             new ValidationError('No se puede eliminar el cliente porque tiene ordenes asociadas')
         );

--- a/test/orderItems.test.js
+++ b/test/orderItems.test.js
@@ -1,4 +1,4 @@
-// Mock del service en lugar de db
+// Mock the service instead of db
 jest.mock('../services/orders-items-service');
 
 const request = require('supertest');
@@ -7,17 +7,17 @@ const ordersItemsService = require('../services/orders-items-service');
 const { ValidationError, NotFoundError } = require('../errors/custom-errors');
 
 describe('Order Items API', () => {
-    // Limpiar mocks después de cada test
+    // Clear mocks after each test
     afterEach(() => {
         jest.clearAllMocks();
     });
 
     // ============================================
-    // POST /api/order-items - Crear item de orden
+    // POST /api/order-items - Create order item
     // ============================================
-    
+
     describe('POST /api/order-items', () => {
-        it('Debería agregar un item de orden', async () => {
+        it('should add an order item', async () => {
             const mockOrderItem = {
                 id: 1,
                 order_id: 1,
@@ -43,7 +43,7 @@ describe('Order Items API', () => {
             });
         });
 
-        it('Debería validar datos faltantes al agregar item de orden (order_id)', async () => {
+        it('should validate missing fields when adding order item (order_id)', async () => {
             ordersItemsService.addOrderItem.mockRejectedValue(
                 new ValidationError('order_id inválido')
             );
@@ -56,7 +56,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'order_id inválido');
         });
 
-        it('Debería validar datos faltantes al agregar item de orden (product_id)', async () => {
+        it('should validate missing fields when adding order item (product_id)', async () => {
             ordersItemsService.addOrderItem.mockRejectedValue(
                 new ValidationError('product_id inválido')
             );
@@ -69,7 +69,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'product_id inválido');
         });
 
-        it('Debería validar datos faltantes al agregar item de orden (quantity)', async () => {
+        it('should validate missing fields when adding order item (quantity)', async () => {
             ordersItemsService.addOrderItem.mockRejectedValue(
                 new ValidationError('quantity inválido')
             );
@@ -82,7 +82,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'quantity inválido');
         });
 
-        it('Debería retornar error si el order_id no existe al agregar item de orden', async () => {
+        it('should return error if order_id does not exist when adding order item', async () => {
             ordersItemsService.addOrderItem.mockRejectedValue(
                 new NotFoundError('Orden no encontrada')
             );
@@ -95,7 +95,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'Orden no encontrada');
         });
 
-        it('Debería retornar error si el product_id no existe al agregar item de orden', async () => {
+        it('should return error if product_id does not exist when adding order item', async () => {
             ordersItemsService.addOrderItem.mockRejectedValue(
                 new NotFoundError('Producto no encontrado')
             );
@@ -108,7 +108,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'Producto no encontrado');
         });
 
-        it('Debería validar quantity negativo', async () => {
+        it('should validate negative quantity', async () => {
             ordersItemsService.addOrderItem.mockRejectedValue(
                 new ValidationError('quantity inválido')
             );
@@ -121,7 +121,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'quantity inválido');
         });
 
-        it('Debería devolver error 500 si hay un problema inesperado al agregar item de orden', async () => {
+        it('should return 500 error on unexpected problem when adding order item', async () => {
             ordersItemsService.addOrderItem.mockRejectedValue(
                 new Error('Error inesperado en la base de datos')
             );
@@ -136,11 +136,11 @@ describe('Order Items API', () => {
     });
 
     // ============================================
-    // GET /api/order-items - Obtener todos
+    // GET /api/order-items - Get all
     // ============================================
 
     describe('GET /api/order-items', () => {
-        it('Debería obtener todos los items de orden', async () => {
+        it('should get all order items', async () => {
             const mockOrderItems = [
                 { id: 1, order_id: 1, product_id: 1, quantity: 2, price: 50 },
                 { id: 2, order_id: 1, product_id: 2, quantity: 1, price: 30 }
@@ -156,7 +156,7 @@ describe('Order Items API', () => {
             expect(ordersItemsService.getAllOrderItems).toHaveBeenCalledWith(undefined, undefined);
         });
 
-        it('Debería obtener items con paginación personalizada', async () => {
+        it('should get items with custom pagination', async () => {
             const mockOrderItems = [
                 { id: 11, order_id: 2, product_id: 1, quantity: 3, price: 75 }
             ];
@@ -170,7 +170,7 @@ describe('Order Items API', () => {
             expect(ordersItemsService.getAllOrderItems).toHaveBeenCalledWith("10", "10");
         });
 
-        it('Debería validar limit inválido', async () => {
+        it('should validate invalid limit', async () => {
             ordersItemsService.getAllOrderItems.mockRejectedValue(
                 new ValidationError('El límite debe ser un número positivo')
             );
@@ -181,7 +181,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'El límite debe ser un número positivo');
         });
 
-        it('Debería validar offset inválido', async () => {
+        it('should validate invalid offset', async () => {
             ordersItemsService.getAllOrderItems.mockRejectedValue(
                 new ValidationError('El offset debe ser un número no negativo')
             );
@@ -192,7 +192,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'El offset debe ser un número no negativo');
         });
 
-        it('Debería devolver error 500 si hay un problema con la base de datos al obtener todos los items', async () => {
+        it('should return 500 error on database problem when fetching all items', async () => {
             ordersItemsService.getAllOrderItems.mockRejectedValue(
                 new Error('DB error')
             );
@@ -209,7 +209,7 @@ describe('Order Items API', () => {
     // ============================================
 
     describe('GET /api/order-items/order/:orderId', () => {
-        it('Debería obtener items de orden por order_id', async () => {
+        it('should get order items by order_id', async () => {
             const mockOrderItems = [
                 { id: 1, order_id: 1, product_id: 1, quantity: 2, price: 50 },
                 { id: 2, order_id: 1, product_id: 2, quantity: 1, price: 30 }
@@ -225,7 +225,7 @@ describe('Order Items API', () => {
             expect(ordersItemsService.getOrderItemsByOrderId).toHaveBeenCalledWith('1');
         });
 
-        it('Debería devolver 404 si no se encuentran items de orden para el order_id proporcionado', async () => {
+        it('should return 404 if no order items found for given order_id', async () => {
             ordersItemsService.getOrderItemsByOrderId.mockRejectedValue(
                 new NotFoundError('No se encontraron items de orden para el ID de orden proporcionado')
             );
@@ -236,7 +236,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'No se encontraron items de orden para el ID de orden proporcionado');
         });
 
-        it('Debería validar order_id inválido', async () => {
+        it('should validate invalid order_id', async () => {
             ordersItemsService.getOrderItemsByOrderId.mockRejectedValue(
                 new ValidationError('order_id inválido')
             );
@@ -247,7 +247,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'order_id inválido');
         });
 
-        it('Debería devolver error 500 si hay un problema con la base de datos al obtener items por order_id', async () => {
+        it('should return 500 error on database problem when fetching items by order_id', async () => {
             ordersItemsService.getOrderItemsByOrderId.mockRejectedValue(
                 new Error('DB error')
             );
@@ -264,7 +264,7 @@ describe('Order Items API', () => {
     // ============================================
 
     describe('DELETE /api/order-items/order/:orderId', () => {
-        it('Debería eliminar todos los items de orden', async () => {
+        it('should delete all order items', async () => {
             const mockDeletedItems = [
                 { id: 1, order_id: 1, product_id: 1, quantity: 2, price: 50 },
                 { id: 2, order_id: 1, product_id: 2, quantity: 1, price: 30 },
@@ -282,7 +282,7 @@ describe('Order Items API', () => {
             expect(ordersItemsService.deleteOrderItemsByOrderId).toHaveBeenCalledWith('1');
         });
 
-        it('Debería retornar 404 si no hay items de orden para eliminar', async () => {
+        it('should return 404 if no order items to delete', async () => {
             ordersItemsService.deleteOrderItemsByOrderId.mockRejectedValue(
                 new NotFoundError('No se encontraron items de orden para el ID de orden proporcionado')
             );
@@ -293,7 +293,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'No se encontraron items de orden para el ID de orden proporcionado');
         });
 
-        it('Debería validar order_id inválido al eliminar', async () => {
+        it('should validate invalid order_id when deleting', async () => {
             ordersItemsService.deleteOrderItemsByOrderId.mockRejectedValue(
                 new ValidationError('order_id inválido')
             );
@@ -304,7 +304,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'order_id inválido');
         });
 
-        it('Debería devolver error 500 si hay un problema con la base de datos al eliminar items', async () => {
+        it('should return 500 error on database problem when deleting items', async () => {
             ordersItemsService.deleteOrderItemsByOrderId.mockRejectedValue(
                 new Error('DB error')
             );
@@ -321,7 +321,7 @@ describe('Order Items API', () => {
     // ============================================
 
     describe('DELETE /api/order-items/order/:orderId/product/:productId', () => {
-        it('Debería eliminar un item de orden por order_id y product_id', async () => {
+        it('should delete an order item by order_id and product_id', async () => {
             const mockDeletedItem = {
                 id: 1,
                 order_id: 1,
@@ -341,7 +341,7 @@ describe('Order Items API', () => {
             expect(ordersItemsService.deleteOrderItemByOrderIdAndProductId).toHaveBeenCalledWith('1', '1');
         });
 
-        it('Debería retornar 404 si el order_id no existe al eliminar item', async () => {
+        it('should return 404 if order_id does not exist when deleting item', async () => {
             ordersItemsService.deleteOrderItemByOrderIdAndProductId.mockRejectedValue(
                 new NotFoundError('Orden no encontrada')
             );
@@ -352,7 +352,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'Orden no encontrada');
         });
 
-        it('Debería retornar 404 si el product_id no existe al eliminar item', async () => {
+        it('should return 404 if product_id does not exist when deleting item', async () => {
             ordersItemsService.deleteOrderItemByOrderIdAndProductId.mockRejectedValue(
                 new NotFoundError('Producto no encontrado')
             );
@@ -363,7 +363,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'Producto no encontrado');
         });
 
-        it('Debería devolver 404 si no se encuentra el item de orden para eliminar', async () => {
+        it('should return 404 if order item not found for deletion', async () => {
             ordersItemsService.deleteOrderItemByOrderIdAndProductId.mockRejectedValue(
                 new NotFoundError('No se encontró el item de orden para el ID de orden y producto proporcionados')
             );
@@ -374,7 +374,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'No se encontró el item de orden para el ID de orden y producto proporcionados');
         });
 
-        it('Debería validar order_id inválido al eliminar item específico', async () => {
+        it('should validate invalid order_id when deleting specific item', async () => {
             ordersItemsService.deleteOrderItemByOrderIdAndProductId.mockRejectedValue(
                 new ValidationError('order_id inválido')
             );
@@ -385,7 +385,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'order_id inválido');
         });
 
-        it('Debería validar product_id inválido al eliminar item específico', async () => {
+        it('should validate invalid product_id when deleting specific item', async () => {
             ordersItemsService.deleteOrderItemByOrderIdAndProductId.mockRejectedValue(
                 new ValidationError('product_id inválido')
             );
@@ -396,7 +396,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'product_id inválido');
         });
 
-        it('Debería devolver error 500 si hay un problema con la base de datos al eliminar item específico', async () => {
+        it('should return 500 error on database problem when deleting specific item', async () => {
             ordersItemsService.deleteOrderItemByOrderIdAndProductId.mockRejectedValue(
                 new Error('DB error')
             );
@@ -413,7 +413,7 @@ describe('Order Items API', () => {
     // ============================================
 
     describe('PATCH /api/order-items/order/:orderId/product/:productId', () => {
-        it('Debería actualizar quantity y price en un item de orden', async () => {
+        it('should update quantity and price on an order item', async () => {
             const mockUpdatedItem = {
                 id: 1,
                 order_id: 1,
@@ -435,7 +435,7 @@ describe('Order Items API', () => {
             expect(ordersItemsService.updateOrderItem).toHaveBeenCalledWith('1', '1', { quantity: 5, price: 100 });
         });
 
-        it('Debería actualizar solo quantity', async () => {
+        it('should update only quantity', async () => {
             const mockUpdatedItem = {
                 id: 1,
                 order_id: 1,
@@ -456,7 +456,7 @@ describe('Order Items API', () => {
             expect(ordersItemsService.updateOrderItem).toHaveBeenCalledWith('1', '1', { quantity: 10 });
         });
 
-        it('Debería actualizar solo price', async () => {
+        it('should update only price', async () => {
             const mockUpdatedItem = {
                 id: 1,
                 order_id: 1,
@@ -477,7 +477,7 @@ describe('Order Items API', () => {
             expect(ordersItemsService.updateOrderItem).toHaveBeenCalledWith('1', '1', { price: 75 });
         });
 
-        it('Debería retornar 400 si no se envían quantity o price al actualizar', async () => {
+        it('should return 400 if neither quantity nor price is sent when updating', async () => {
             ordersItemsService.updateOrderItem.mockRejectedValue(
                 new ValidationError('Debe proporcionar quantity o price para actualizar')
             );
@@ -490,7 +490,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'Debe proporcionar quantity o price para actualizar');
         });
 
-        it('Debería validar quantity inválido al actualizar', async () => {
+        it('should validate invalid quantity when updating', async () => {
             ordersItemsService.updateOrderItem.mockRejectedValue(
                 new ValidationError('quantity inválido')
             );
@@ -503,7 +503,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'quantity inválido');
         });
 
-        it('Debería validar price inválido al actualizar', async () => {
+        it('should validate invalid price when updating', async () => {
             ordersItemsService.updateOrderItem.mockRejectedValue(
                 new ValidationError('price inválido')
             );
@@ -516,7 +516,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'price inválido');
         });
 
-        it('Debería devolver 404 si no encuentra la orden para actualizar', async () => {
+        it('should return 404 if order not found when updating', async () => {
             ordersItemsService.updateOrderItem.mockRejectedValue(
                 new NotFoundError('Orden no encontrada')
             );
@@ -529,7 +529,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'Orden no encontrada');
         });
 
-        it('Debería devolver 404 si no encuentra el producto para actualizar', async () => {
+        it('should return 404 if product not found when updating', async () => {
             ordersItemsService.updateOrderItem.mockRejectedValue(
                 new NotFoundError('Producto no encontrado')
             );
@@ -542,7 +542,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'Producto no encontrado');
         });
 
-        it('Debería devolver 404 si no se encuentra el item para actualizar', async () => {
+        it('should return 404 if order item not found when updating', async () => {
             ordersItemsService.updateOrderItem.mockRejectedValue(
                 new NotFoundError('No se encontró el item de orden para el ID de orden y producto proporcionados')
             );
@@ -555,7 +555,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'No se encontró el item de orden para el ID de orden y producto proporcionados');
         });
 
-        it('Debería validar order_id inválido al actualizar', async () => {
+        it('should validate invalid order_id when updating', async () => {
             ordersItemsService.updateOrderItem.mockRejectedValue(
                 new ValidationError('order_id inválido')
             );
@@ -568,7 +568,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'order_id inválido');
         });
 
-        it('Debería validar product_id inválido al actualizar', async () => {
+        it('should validate invalid product_id when updating', async () => {
             ordersItemsService.updateOrderItem.mockRejectedValue(
                 new ValidationError('product_id inválido')
             );
@@ -581,7 +581,7 @@ describe('Order Items API', () => {
             expect(res.body).toHaveProperty('error', 'product_id inválido');
         });
 
-        it('Debería devolver error 500 si hay un problema con la base de datos al actualizar', async () => {
+        it('should return 500 error on database problem when updating', async () => {
             ordersItemsService.updateOrderItem.mockRejectedValue(
                 new Error('DB error')
             );

--- a/test/orders.test.js
+++ b/test/orders.test.js
@@ -1,4 +1,4 @@
-// Mockear las dependencias ANTES de importarlas
+// Mock dependencies BEFORE importing them
 jest.mock("../repositories/orders-repository");
 jest.mock("../repositories/customer-repository");
 jest.mock("../repositories/addresses-repository");
@@ -10,21 +10,21 @@ const customerRepository = require("../repositories/customer-repository");
 const addressRepository = require("../repositories/addresses-repository");
 
 describe("Orders Controller Tests", () => {
-  // Limpiar mocks después de cada test
+  // Clear mocks after each test
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   describe("POST /api/orders", () => {
-    it("Debería crear una nueva orden con éxito", async () => {
-      // Arrange: Configurar mocks
+    it("should create a new order successfully", async () => {
+      // Arrange: configure mocks
       customerRepository.getById.mockResolvedValue({
         id: 1,
         name: "John Doe",
       });
       addressRepository.getById.mockResolvedValue({
         id: 1,
-        customer_id: 1, 
+        customer_id: 1,
         address_text: "123 Main St",
       });
 
@@ -35,28 +35,27 @@ describe("Orders Controller Tests", () => {
         id: 1,
         customer_id: 1,
         address_id: 1,
-        total: 0, 
+        total: 0, // always 0 on creation
         payment_method_id: 1,
         status_id: 1,
         created_at: new Date(),
       });
 
-      // Act: Hacer request
+      // Act: make request
       const res = await request(app).post("/api/orders").send({
         customer_id: 1,
         address_id: 1,
-        payment_method_id: 1, 
-        status_id: 1, 
+        payment_method_id: 1,
+        status_id: 1,
       });
 
-      // Assert: Verificar respuesta
+      // Assert: verify response
       expect(res.status).toBe(201);
       expect(res.body).toHaveProperty("message", "Orden creada exitosamente");
       expect(res.body.order).toHaveProperty("id", 1);
       expect(res.body.order).toHaveProperty("customer_id", 1);
-      expect(res.body.order).toHaveProperty("total", 0); // ✅ Siempre 0 al crear
+      expect(res.body.order).toHaveProperty("total", 0); // always 0 on creation
 
-      // Verificar que los métodos fueron llamados correctamente
       expect(customerRepository.getById).toHaveBeenCalledWith(1);
       expect(addressRepository.getById).toHaveBeenCalledWith(1);
       expect(ordersRepository.create).toHaveBeenCalledWith(
@@ -64,12 +63,12 @@ describe("Orders Controller Tests", () => {
           customer_id: 1,
           address_id: 1,
           payment_method_id: 1,
-          total: 0, 
+          total: 0,
         })
       );
     });
 
-    it("Debería devolver error cuando no existe el cliente", async () => {
+    it("should return error when customer does not exist", async () => {
       customerRepository.getById.mockResolvedValue(null);
 
       const res = await request(app).post("/api/orders").send({
@@ -86,7 +85,7 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.create).not.toHaveBeenCalled();
     });
 
-    it("Debería devolver error cuando no existe la dirección", async () => {
+    it("should return error when address does not exist", async () => {
       customerRepository.getById.mockResolvedValue({ id: 1 });
       addressRepository.getById.mockResolvedValue(null);
 
@@ -103,20 +102,20 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.create).not.toHaveBeenCalled();
     });
 
-    it("Debería devolver error cuando la dirección NO pertenece al cliente", async () => {
+    it("should return error when address does NOT belong to customer", async () => {
       customerRepository.getById.mockResolvedValue({
         id: 1,
         name: "John Doe",
       });
       addressRepository.getById.mockResolvedValue({
         id: 5,
-        customer_id: 10, // ✅ Dirección pertenece a otro cliente
+        customer_id: 10, // address belongs to a different customer
         address_text: "456 Other St",
       });
 
       const res = await request(app).post("/api/orders").send({
         customer_id: 1,
-        address_id: 5, // Dirección del cliente 10
+        address_id: 5, // address belongs to customer 10
         payment_method_id: 1,
         status_id: 1,
       });
@@ -128,7 +127,7 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.create).not.toHaveBeenCalled();
     });
 
-    it("Debería devolver error cuando faltan datos obligatorios (customer_id)", async () => {
+    it("should return error when required field is missing (customer_id)", async () => {
       const res = await request(app).post("/api/orders").send({
         address_id: 1,
         payment_method_id: 1,
@@ -139,7 +138,7 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.create).not.toHaveBeenCalled();
     });
 
-    it("Debería devolver error cuando faltan datos obligatorios (address_id)", async () => {
+    it("should return error when required field is missing (address_id)", async () => {
       const res = await request(app).post("/api/orders").send({
         customer_id: 1,
         payment_method_id: 1,
@@ -149,27 +148,27 @@ describe("Orders Controller Tests", () => {
       expect(res.body.error).toContain("address_id inválido");
     });
 
-    it("Debería devolver error cuando payment_method_id es inválido", async () => {
+    it("should return error when payment_method_id is invalid", async () => {
       customerRepository.getById.mockResolvedValue({ id: 1 });
       addressRepository.getById.mockResolvedValue({
         id: 1,
         customer_id: 1,
       });
 
-      // ✅ Mock: payment_method no existe o no está activo
+      // payment method does not exist or is inactive
       ordersRepository.paymentMethodExists.mockResolvedValue(false);
 
       const res = await request(app).post("/api/orders").send({
         customer_id: 1,
         address_id: 1,
-        payment_method_id: 999, // ✅ ID inválido
+        payment_method_id: 999, // invalid ID
       });
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("Método de pago no válido o inactivo");
     });
 
-    it("Debería devolver error cuando status_id es inválido", async () => {
+    it("should return error when status_id is invalid", async () => {
       customerRepository.getById.mockResolvedValue({ id: 1 });
       addressRepository.getById.mockResolvedValue({
         id: 1,
@@ -183,21 +182,21 @@ describe("Orders Controller Tests", () => {
         customer_id: 1,
         address_id: 1,
         payment_method_id: 1,
-        status_id: 999, // ✅ ID inválido
+        status_id: 999, // invalid ID
       });
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("Estado del pedido no válido");
     });
 
-    it("Debería manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       customerRepository.getById.mockResolvedValue({
         id: 1,
         name: "John Doe",
       });
       addressRepository.getById.mockResolvedValue({
         id: 1,
-        customer_id: 1, 
+        customer_id: 1,
       });
       ordersRepository.paymentMethodExists.mockResolvedValue(true);
       ordersRepository.orderStatusExists.mockResolvedValue(true);
@@ -217,7 +216,7 @@ describe("Orders Controller Tests", () => {
   });
 
   describe("PUT /api/orders/:id/total", () => {
-    it("Debería actualizar el total de la orden con éxito", async () => {
+    it("should update order total successfully", async () => {
       ordersRepository.getById.mockResolvedValue({ id: 1, total: 0 });
       ordersRepository.calculateAndUpdateTotal.mockResolvedValue({
         id: 1,
@@ -228,7 +227,7 @@ describe("Orders Controller Tests", () => {
         status_id: 1,
       });
 
-      const res = await request(app).put("/api/orders/1/total"); // ✅ PUT
+      const res = await request(app).put("/api/orders/1/total");
 
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty(
@@ -238,12 +237,10 @@ describe("Orders Controller Tests", () => {
       expect(res.body.order).toHaveProperty("id", 1);
       expect(res.body.order).toHaveProperty("total", 150.5);
       expect(ordersRepository.getById).toHaveBeenCalledWith("1");
-      expect(ordersRepository.calculateAndUpdateTotal).toHaveBeenCalledWith(
-        "1"
-      );
+      expect(ordersRepository.calculateAndUpdateTotal).toHaveBeenCalledWith("1");
     });
 
-    it("Debería devolver error cuando no existe la orden", async () => {
+    it("should return error when order does not exist", async () => {
       ordersRepository.getById.mockResolvedValue(null);
 
       const res = await request(app).put("/api/orders/999/total");
@@ -253,14 +250,14 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.calculateAndUpdateTotal).not.toHaveBeenCalled();
     });
 
-    it("Debería devolver error con ID inválido", async () => {
+    it("should return error with invalid ID", async () => {
       const res = await request(app).put("/api/orders/invalid/total");
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("ID inválido");
     });
 
-    it("Debería manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       ordersRepository.getById.mockResolvedValue({ id: 1 });
       ordersRepository.calculateAndUpdateTotal.mockRejectedValue(
         new Error("DB error")
@@ -274,7 +271,7 @@ describe("Orders Controller Tests", () => {
   });
 
   describe("GET /api/orders", () => {
-    it("Debería traer todas las órdenes", async () => {
+    it("should fetch all orders", async () => {
       const mockOrders = [
         { id: 1, customer_id: 1, total: 100, status: "pending" },
         { id: 2, customer_id: 2, total: 200, status: "shipped" },
@@ -289,7 +286,7 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.getAll).toHaveBeenCalledWith(100, 0);
     });
 
-    it("Debería traer órdenes con paginación", async () => {
+    it("should fetch orders with pagination", async () => {
       const mockOrders = [
         { id: 1, customer_id: 1, total: 100, status: "pending" },
       ];
@@ -301,14 +298,14 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.getAll).toHaveBeenCalledWith(10, 5);
     });
 
-    it("Debería devolver error con límite inválido", async () => {
+    it("should return error with invalid limit", async () => {
       const res = await request(app).get("/api/orders?limit=-5");
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("límite");
     });
 
-    it("Debería manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       ordersRepository.getAll.mockRejectedValue(new Error("DB error"));
 
       const res = await request(app).get("/api/orders");
@@ -319,7 +316,7 @@ describe("Orders Controller Tests", () => {
   });
 
   describe("GET /api/orders/:id", () => {
-    it("Debería traer una orden por ID", async () => {
+    it("should fetch an order by ID", async () => {
       ordersRepository.getById.mockResolvedValue({
         id: 1,
         customer_id: 1,
@@ -337,7 +334,7 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.getById).toHaveBeenCalledWith("1");
     });
 
-    it("Debería devolver error cuando no existe la orden", async () => {
+    it("should return error when order does not exist", async () => {
       ordersRepository.getById.mockResolvedValue(null);
 
       const res = await request(app).get("/api/orders/999");
@@ -346,14 +343,14 @@ describe("Orders Controller Tests", () => {
       expect(res.body).toHaveProperty("error", "Orden no encontrada");
     });
 
-    it("Debería devolver error con ID inválido", async () => {
+    it("should return error with invalid ID", async () => {
       const res = await request(app).get("/api/orders/abc");
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("ID inválido");
     });
 
-    it("Debería manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       ordersRepository.getById.mockRejectedValue(new Error("DB error"));
 
       const res = await request(app).get("/api/orders/1");
@@ -364,7 +361,7 @@ describe("Orders Controller Tests", () => {
   });
 
   describe("GET /api/orders/customer/:customer_id", () => {
-    it("Debería traer órdenes por ID de cliente", async () => {
+    it("should fetch orders by customer ID", async () => {
       const mockOrders = [
         { id: 1, customer_id: 1, total: 100 },
         { id: 2, customer_id: 1, total: 200 },
@@ -379,7 +376,7 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.getByCustomerId).toHaveBeenCalledWith("1");
     });
 
-    it("Debería devolver array vacío cuando no hay órdenes para el cliente", async () => {
+    it("should return empty array when customer has no orders", async () => {
       ordersRepository.getByCustomerId.mockResolvedValue([]);
 
       const res = await request(app).get("/api/orders/customer/999");
@@ -388,14 +385,14 @@ describe("Orders Controller Tests", () => {
       expect(res.body).toEqual([]);
     });
 
-    it("Debería devolver error con customer_id inválido", async () => {
+    it("should return error with invalid customer_id", async () => {
       const res = await request(app).get("/api/orders/customer/invalid");
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("ID inválido");
     });
 
-    it("Debería manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       ordersRepository.getByCustomerId.mockRejectedValue(new Error("DB error"));
 
       const res = await request(app).get("/api/orders/customer/1");
@@ -406,7 +403,7 @@ describe("Orders Controller Tests", () => {
   });
 
   describe("DELETE /api/orders/:id", () => {
-    it("Debería eliminar una orden por ID", async () => {
+    it("should delete an order by ID", async () => {
       const mockOrder = {
         id: 1,
         customer_id: 1,
@@ -421,16 +418,13 @@ describe("Orders Controller Tests", () => {
       const res = await request(app).delete("/api/orders/1");
 
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty(
-        "message",
-        "Orden eliminada exitosamente"
-      );
+      expect(res.body).toHaveProperty("message", "Orden eliminada exitosamente");
       expect(res.body.order).toHaveProperty("id", 1);
       expect(ordersRepository.getById).toHaveBeenCalledWith("1");
       expect(ordersRepository.delete).toHaveBeenCalledWith("1");
     });
 
-    it("Debería devolver error cuando no existe la orden", async () => {
+    it("should return error when order does not exist", async () => {
       ordersRepository.getById.mockResolvedValue(null);
 
       const res = await request(app).delete("/api/orders/999");
@@ -440,14 +434,14 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.delete).not.toHaveBeenCalled();
     });
 
-    it("Debería devolver error con ID inválido", async () => {
+    it("should return error with invalid ID", async () => {
       const res = await request(app).delete("/api/orders/invalid");
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("ID inválido");
     });
 
-    it("Debería manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       ordersRepository.getById.mockResolvedValue({ id: 1 });
       ordersRepository.delete.mockRejectedValue(new Error("DB error"));
 
@@ -459,7 +453,7 @@ describe("Orders Controller Tests", () => {
   });
 
   describe("PATCH /api/orders/:id", () => {
-    it("Debería actualizar el status_id de la orden", async () => {
+    it("should update order status_id", async () => {
       ordersRepository.getById.mockResolvedValue({ id: 1, status_id: 1 });
       ordersRepository.orderStatusExists.mockResolvedValue(true);
       ordersRepository.updatePartial.mockResolvedValue({
@@ -476,17 +470,14 @@ describe("Orders Controller Tests", () => {
         .send({ status_id: 2 });
 
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty(
-        "message",
-        "Orden actualizada exitosamente"
-      );
+      expect(res.body).toHaveProperty("message", "Orden actualizada exitosamente");
       expect(res.body.order).toHaveProperty("status_id", 2);
       expect(ordersRepository.updatePartial).toHaveBeenCalledWith("1", {
         status_id: 2,
       });
     });
 
-    it("Debería devolver error cuando intenta actualizar customer_id (campo inmutable)", async () => {
+    it("should return error when attempting to update customer_id (immutable field)", async () => {
       const res = await request(app)
         .patch("/api/orders/1")
         .send({ customer_id: 2 });
@@ -497,7 +488,7 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.updatePartial).not.toHaveBeenCalled();
     });
 
-    it("Debería devolver error cuando intenta actualizar payment_method_id (campo inmutable)", async () => {
+    it("should return error when attempting to update payment_method_id (immutable field)", async () => {
       const res = await request(app)
         .patch("/api/orders/1")
         .send({ payment_method_id: 2 });
@@ -507,8 +498,7 @@ describe("Orders Controller Tests", () => {
       expect(res.body.error).toContain("payment_method_id");
     });
 
-    // 🔥 NUEVA PRUEBA: No permite actualizar total
-    it("Debería devolver error cuando intenta actualizar total (debe usar PUT /total)", async () => {
+    it("should return error when attempting to update total (use PUT /total instead)", async () => {
       const res = await request(app)
         .patch("/api/orders/1")
         .send({ total: 500 });
@@ -518,7 +508,7 @@ describe("Orders Controller Tests", () => {
       expect(res.body.error).toContain("total");
     });
 
-    it("Debería devolver error cuando no existe la orden", async () => {
+    it("should return error when order does not exist", async () => {
       ordersRepository.getById.mockResolvedValue(null);
 
       const res = await request(app)
@@ -530,7 +520,7 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.updatePartial).not.toHaveBeenCalled();
     });
 
-    it("Debería devolver error con ID inválido", async () => {
+    it("should return error with invalid ID", async () => {
       const res = await request(app)
         .patch("/api/orders/invalid")
         .send({ status_id: 2 });
@@ -539,7 +529,7 @@ describe("Orders Controller Tests", () => {
       expect(res.body.error).toContain("ID inválido");
     });
 
-    it("Debería manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       ordersRepository.getById.mockResolvedValue({ id: 1 });
       ordersRepository.orderStatusExists.mockResolvedValue(true);
       ordersRepository.updatePartial.mockRejectedValue(new Error("DB error"));
@@ -554,7 +544,7 @@ describe("Orders Controller Tests", () => {
   });
 
   describe("PATCH /api/orders/:id/status", () => {
-    it("Debería actualizar el estado de la orden", async () => {
+    it("should update order status", async () => {
       ordersRepository.getById.mockResolvedValue({ id: 1 });
       ordersRepository.orderStatusExists.mockResolvedValue(true);
       ordersRepository.updateStatus.mockResolvedValue({
@@ -563,12 +553,12 @@ describe("Orders Controller Tests", () => {
         address_id: 1,
         total: 100,
         payment_method_id: 1,
-        status_id: 2, // ✅ CORREGIDO: Ahora es ID
+        status_id: 2,
       });
 
       const res = await request(app)
         .patch("/api/orders/1/status")
-        .send({ status_id: 2 }); // ✅ CORREGIDO: Enviar ID
+        .send({ status_id: 2 });
 
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty(
@@ -579,14 +569,14 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.updateStatus).toHaveBeenCalledWith("1", 2);
     });
 
-    it("Debería devolver error cuando falta el estado", async () => {
+    it("should return error when status is missing", async () => {
       const res = await request(app).patch("/api/orders/1/status").send({});
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("status_id inválido");
     });
 
-    it("Debería devolver error con status_id inválido", async () => {
+    it("should return error with invalid status_id", async () => {
       ordersRepository.orderStatusExists.mockResolvedValue(false);
 
       const res = await request(app)
@@ -597,7 +587,7 @@ describe("Orders Controller Tests", () => {
       expect(res.body.error).toContain("Estado del pedido no válido");
     });
 
-    it("Debería devolver error cuando no existe la orden", async () => {
+    it("should return error when order does not exist", async () => {
       ordersRepository.getById.mockResolvedValue(null);
       ordersRepository.orderStatusExists.mockResolvedValue(true);
 
@@ -610,7 +600,7 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.updateStatus).not.toHaveBeenCalled();
     });
 
-    it("Debería devolver error con ID inválido", async () => {
+    it("should return error with invalid ID", async () => {
       const res = await request(app)
         .patch("/api/orders/invalid/status")
         .send({ status_id: 2 });
@@ -619,7 +609,7 @@ describe("Orders Controller Tests", () => {
       expect(res.body.error).toContain("ID inválido");
     });
 
-    it("Debería manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       ordersRepository.getById.mockResolvedValue({ id: 1 });
       ordersRepository.orderStatusExists.mockResolvedValue(true);
       ordersRepository.updateStatus.mockRejectedValue(new Error("DB error"));
@@ -634,7 +624,7 @@ describe("Orders Controller Tests", () => {
   });
 
   describe("GET /api/orders/count", () => {
-    it("Debería contar las órdenes del día", async () => {
+    it("should count today's orders", async () => {
       ordersRepository.countForDay.mockResolvedValue(15);
 
       const res = await request(app).get("/api/orders/count");
@@ -646,7 +636,7 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.countForDay).toHaveBeenCalled();
     });
 
-    it("Debería retornar 0 cuando no hay órdenes del día", async () => {
+    it("should return 0 when no orders for the day", async () => {
       ordersRepository.countForDay.mockResolvedValue(0);
 
       const res = await request(app).get("/api/orders/count");
@@ -655,7 +645,7 @@ describe("Orders Controller Tests", () => {
       expect(res.body).toHaveProperty("count", 0);
     });
 
-    it("Debería manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       ordersRepository.countForDay.mockRejectedValue(new Error("DB error"));
 
       const res = await request(app).get("/api/orders/count");
@@ -666,7 +656,7 @@ describe("Orders Controller Tests", () => {
   });
 
   describe("GET /api/orders/status/:status_id", () => {
-    it("Debería traer órdenes por estado", async () => {
+    it("should fetch orders by status", async () => {
       const mockOrders = [
         { id: 1, customer_id: 1, total: 100, status_id: 1 },
         { id: 2, customer_id: 2, total: 200, status_id: 1 },
@@ -682,7 +672,7 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.getByStatus).toHaveBeenCalledWith("1", 100, 0);
     });
 
-    it("Debería manejar error cuando el estado no existe", async () => {
+    it("should handle error when status does not exist", async () => {
       ordersRepository.orderStatusExists.mockResolvedValue(false);
 
       const res = await request(app).get("/api/orders/status/999");
@@ -692,29 +682,26 @@ describe("Orders Controller Tests", () => {
       expect(ordersRepository.getByStatus).not.toHaveBeenCalled();
     });
 
-    it("Debería traer órdenes por estado con paginación", async () => {
+    it("should fetch orders by status with pagination", async () => {
       const mockOrders = [{ id: 1, customer_id: 1, total: 100, status_id: 2 }];
       ordersRepository.orderStatusExists.mockResolvedValue(true);
       ordersRepository.getByStatus.mockResolvedValue(mockOrders);
 
-      const res = await request(app).get(
-        "/api/orders/status/2?limit=50&offset=10"
-      );
+      const res = await request(app).get("/api/orders/status/2?limit=50&offset=10");
 
       expect(res.status).toBe(200);
       expect(res.body).toHaveLength(1);
-   
       expect(ordersRepository.getByStatus).toHaveBeenCalledWith("2", 50, 10);
     });
 
-    it("Debería devolver error con status_id inválido", async () => {
+    it("should return error with invalid status_id", async () => {
       const res = await request(app).get("/api/orders/status/invalid");
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("ID inválido");
     });
 
-    it("Debería manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       ordersRepository.orderStatusExists.mockResolvedValue(true);
       ordersRepository.getByStatus.mockRejectedValue(new Error("DB error"));
 

--- a/test/payments.test.js
+++ b/test/payments.test.js
@@ -13,7 +13,7 @@ describe("Payments Controller Tests", () => {
   // POST /api/payments
   // ============================================
   describe("POST /api/payments", () => {
-    it("Deberia crear un pago digital exitosamente", async () => {
+    it("should create a digital payment successfully", async () => {
       paymentsRepository.getOrderWithPaymentMethod.mockResolvedValue({
         id: 1,
         total: 25000,
@@ -46,7 +46,7 @@ describe("Payments Controller Tests", () => {
       );
     });
 
-    it("Deberia crear un pago digital sin URL de comprobante", async () => {
+    it("should create a digital payment without receipt URL", async () => {
       paymentsRepository.getOrderWithPaymentMethod.mockResolvedValue({
         id: 1,
         total: 25000,
@@ -69,7 +69,7 @@ describe("Payments Controller Tests", () => {
       expect(paymentsRepository.create).toHaveBeenCalledWith({ order_id: 1 });
     });
 
-    it("Deberia crear un pago en efectivo y calcular el cambio", async () => {
+    it("should create a cash payment and calculate change", async () => {
       paymentsRepository.getOrderWithPaymentMethod.mockResolvedValue({
         id: 2,
         total: 18000,
@@ -100,7 +100,7 @@ describe("Payments Controller Tests", () => {
       );
     });
 
-    it("Deberia crear un pago en efectivo sin cash_given", async () => {
+    it("should create a cash payment without cash_given", async () => {
       paymentsRepository.getOrderWithPaymentMethod.mockResolvedValue({
         id: 2,
         total: 18000,
@@ -122,7 +122,7 @@ describe("Payments Controller Tests", () => {
       expect(paymentsRepository.create).toHaveBeenCalledWith({ order_id: 2 });
     });
 
-    it("Deberia devolver error cuando order_id es invalido", async () => {
+    it("should return error when order_id is invalid", async () => {
       const res = await request(app).post("/api/payments").send({
         order_id: "abc",
       });
@@ -132,14 +132,14 @@ describe("Payments Controller Tests", () => {
       expect(paymentsRepository.create).not.toHaveBeenCalled();
     });
 
-    it("Deberia devolver error cuando falta order_id", async () => {
+    it("should return error when order_id is missing", async () => {
       const res = await request(app).post("/api/payments").send({});
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("order_id invalido");
     });
 
-    it("Deberia devolver 404 cuando la orden no existe", async () => {
+    it("should return 404 when order does not exist", async () => {
       paymentsRepository.getOrderWithPaymentMethod.mockResolvedValue(null);
 
       const res = await request(app).post("/api/payments").send({
@@ -150,7 +150,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.error).toContain("Orden no encontrada");
     });
 
-    it("Deberia devolver 409 cuando ya existe un pago para la orden", async () => {
+    it("should return 409 when payment already exists for order", async () => {
       paymentsRepository.getOrderWithPaymentMethod.mockResolvedValue({
         id: 1,
         total: 25000,
@@ -172,7 +172,7 @@ describe("Payments Controller Tests", () => {
       expect(paymentsRepository.create).not.toHaveBeenCalled();
     });
 
-    it("Deberia devolver error cuando cash_given es negativo en pago efectivo", async () => {
+    it("should return error when cash_given is negative for cash payment", async () => {
       paymentsRepository.getOrderWithPaymentMethod.mockResolvedValue({
         id: 1,
         total: 18000,
@@ -190,7 +190,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.error).toContain("cash_given debe ser un numero valido");
     });
 
-    it("Deberia manejar error de base de datos al crear", async () => {
+    it("should handle database errors on create", async () => {
       paymentsRepository.getOrderWithPaymentMethod.mockResolvedValue({
         id: 1,
         total: 25000,
@@ -213,7 +213,7 @@ describe("Payments Controller Tests", () => {
   // GET /api/payments
   // ============================================
   describe("GET /api/payments", () => {
-    it("Deberia traer todos los pagos", async () => {
+    it("should fetch all payments", async () => {
       const mockPayments = [
         { id: 1, order_id: 1, status: "pending" },
         { id: 2, order_id: 2, status: "verified" },
@@ -227,7 +227,7 @@ describe("Payments Controller Tests", () => {
       expect(paymentsRepository.getAll).toHaveBeenCalledWith(100, 0);
     });
 
-    it("Deberia traer pagos con paginacion", async () => {
+    it("should fetch payments with pagination", async () => {
       paymentsRepository.getAll.mockResolvedValue([]);
 
       const res = await request(app).get("/api/payments?limit=10&offset=5");
@@ -236,14 +236,14 @@ describe("Payments Controller Tests", () => {
       expect(paymentsRepository.getAll).toHaveBeenCalledWith(10, 5);
     });
 
-    it("Deberia devolver error con limite invalido", async () => {
+    it("should return error with invalid limit", async () => {
       const res = await request(app).get("/api/payments?limit=-5");
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("límite");
     });
 
-    it("Deberia manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       paymentsRepository.getAll.mockRejectedValue(new Error("DB error"));
 
       const res = await request(app).get("/api/payments");
@@ -257,7 +257,7 @@ describe("Payments Controller Tests", () => {
   // GET /api/payments/status/:status
   // ============================================
   describe("GET /api/payments/status/:status", () => {
-    it("Deberia traer pagos por estado pending", async () => {
+    it("should fetch payments by pending status", async () => {
       const mockPayments = [
         { id: 1, order_id: 1, status: "pending" },
         { id: 3, order_id: 3, status: "pending" },
@@ -271,7 +271,7 @@ describe("Payments Controller Tests", () => {
       expect(paymentsRepository.getByStatus).toHaveBeenCalledWith("pending", 100, 0);
     });
 
-    it("Deberia traer pagos por estado verified", async () => {
+    it("should fetch payments by verified status", async () => {
       paymentsRepository.getByStatus.mockResolvedValue([]);
 
       const res = await request(app).get("/api/payments/status/verified");
@@ -280,7 +280,7 @@ describe("Payments Controller Tests", () => {
       expect(paymentsRepository.getByStatus).toHaveBeenCalledWith("verified", 100, 0);
     });
 
-    it("Deberia traer pagos por estado con paginacion", async () => {
+    it("should fetch payments by status with pagination", async () => {
       paymentsRepository.getByStatus.mockResolvedValue([]);
 
       const res = await request(app).get(
@@ -291,14 +291,14 @@ describe("Payments Controller Tests", () => {
       expect(paymentsRepository.getByStatus).toHaveBeenCalledWith("pending", 20, 10);
     });
 
-    it("Deberia devolver error con estado invalido", async () => {
+    it("should return error with invalid status", async () => {
       const res = await request(app).get("/api/payments/status/invalid_status");
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("Estado invalido");
     });
 
-    it("Deberia manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       paymentsRepository.getByStatus.mockRejectedValue(new Error("DB error"));
 
       const res = await request(app).get("/api/payments/status/pending");
@@ -312,7 +312,7 @@ describe("Payments Controller Tests", () => {
   // GET /api/payments/order/:order_id
   // ============================================
   describe("GET /api/payments/order/:order_id", () => {
-    it("Deberia traer el pago de una orden", async () => {
+    it("should fetch payment for an order", async () => {
       paymentsRepository.getByOrderId.mockResolvedValue({
         id: 1,
         order_id: 1,
@@ -329,7 +329,7 @@ describe("Payments Controller Tests", () => {
       expect(paymentsRepository.getByOrderId).toHaveBeenCalledWith("1");
     });
 
-    it("Deberia devolver 404 cuando no existe pago para la orden", async () => {
+    it("should return 404 when no payment exists for order", async () => {
       paymentsRepository.getByOrderId.mockResolvedValue(null);
 
       const res = await request(app).get("/api/payments/order/999");
@@ -338,14 +338,14 @@ describe("Payments Controller Tests", () => {
       expect(res.body.error).toContain("Pago no encontrado para esta orden");
     });
 
-    it("Deberia devolver error con order_id invalido", async () => {
+    it("should return error with invalid order_id", async () => {
       const res = await request(app).get("/api/payments/order/abc");
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("order_id invalido");
     });
 
-    it("Deberia manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       paymentsRepository.getByOrderId.mockRejectedValue(new Error("DB error"));
 
       const res = await request(app).get("/api/payments/order/1");
@@ -359,7 +359,7 @@ describe("Payments Controller Tests", () => {
   // PATCH /api/payments/order/:order_id/verify
   // ============================================
   describe("PATCH /api/payments/order/:order_id/verify", () => {
-    it("Deberia verificar un pago exitosamente", async () => {
+    it("should verify a payment successfully", async () => {
       paymentsRepository.getByOrderId.mockResolvedValue({
         id: 1,
         order_id: 1,
@@ -387,7 +387,7 @@ describe("Payments Controller Tests", () => {
       });
     });
 
-    it("Deberia rechazar un pago exitosamente", async () => {
+    it("should reject a payment successfully", async () => {
       paymentsRepository.getByOrderId.mockResolvedValue({
         id: 1,
         order_id: 1,
@@ -415,7 +415,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.payment).toHaveProperty("admin_notes", "Comprobante ilegible");
     });
 
-    it("Deberia devolver error cuando el pago no esta pendiente", async () => {
+    it("should return error when payment is not pending", async () => {
       paymentsRepository.getByOrderId.mockResolvedValue({
         id: 1,
         order_id: 1,
@@ -431,7 +431,7 @@ describe("Payments Controller Tests", () => {
       expect(paymentsRepository.verify).not.toHaveBeenCalled();
     });
 
-    it("Deberia devolver 404 cuando no existe el pago", async () => {
+    it("should return 404 when payment does not exist", async () => {
       paymentsRepository.getByOrderId.mockResolvedValue(null);
 
       const res = await request(app)
@@ -442,7 +442,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.error).toContain("Pago no encontrado para esta orden");
     });
 
-    it("Deberia devolver error cuando falta verified_by", async () => {
+    it("should return error when verified_by is missing", async () => {
       const res = await request(app)
         .patch("/api/payments/order/1/verify")
         .send({ status: "verified" });
@@ -451,7 +451,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.error).toContain("verified_by es obligatorio");
     });
 
-    it("Deberia devolver error cuando status de verificacion es invalido", async () => {
+    it("should return error when verification status is invalid", async () => {
       const res = await request(app)
         .patch("/api/payments/order/1/verify")
         .send({ verified_by: "admin", status: "pending" });
@@ -460,7 +460,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.error).toContain("El estado de verificacion debe ser");
     });
 
-    it("Deberia devolver error con order_id invalido", async () => {
+    it("should return error with invalid order_id", async () => {
       const res = await request(app)
         .patch("/api/payments/order/abc/verify")
         .send({ verified_by: "admin", status: "verified" });
@@ -469,7 +469,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.error).toContain("order_id invalido");
     });
 
-    it("Deberia manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       paymentsRepository.getByOrderId.mockResolvedValue({
         id: 1,
         order_id: 1,
@@ -490,7 +490,7 @@ describe("Payments Controller Tests", () => {
   // PATCH /api/payments/order/:order_id/receipt
   // ============================================
   describe("PATCH /api/payments/order/:order_id/receipt", () => {
-    it("Deberia actualizar la imagen del comprobante exitosamente", async () => {
+    it("should update receipt image successfully", async () => {
       paymentsRepository.getByOrderId.mockResolvedValue({
         id: 1,
         order_id: 1,
@@ -515,7 +515,7 @@ describe("Payments Controller Tests", () => {
       );
     });
 
-    it("Deberia devolver error cuando el pago no esta pendiente", async () => {
+    it("should return error when payment is not pending", async () => {
       paymentsRepository.getByOrderId.mockResolvedValue({
         id: 1,
         order_id: 1,
@@ -533,7 +533,7 @@ describe("Payments Controller Tests", () => {
       expect(paymentsRepository.updateReceiptImage).not.toHaveBeenCalled();
     });
 
-    it("Deberia devolver 404 cuando no existe el pago", async () => {
+    it("should return 404 when payment does not exist", async () => {
       paymentsRepository.getByOrderId.mockResolvedValue(null);
 
       const res = await request(app)
@@ -544,7 +544,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.error).toContain("Pago no encontrado para esta orden");
     });
 
-    it("Deberia devolver error cuando falta receipt_image_url", async () => {
+    it("should return error when receipt_image_url is missing", async () => {
       const res = await request(app)
         .patch("/api/payments/order/1/receipt")
         .send({});
@@ -553,7 +553,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.error).toContain("La URL del comprobante es obligatoria");
     });
 
-    it("Deberia devolver error cuando receipt_image_url excede 500 caracteres", async () => {
+    it("should return error when receipt_image_url exceeds 500 characters", async () => {
       const longUrl = "https://example.com/" + "a".repeat(500);
 
       const res = await request(app)
@@ -564,7 +564,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.error).toContain("no puede exceder 500 caracteres");
     });
 
-    it("Deberia devolver error con order_id invalido", async () => {
+    it("should return error with invalid order_id", async () => {
       const res = await request(app)
         .patch("/api/payments/order/abc/receipt")
         .send({ receipt_image_url: "https://example.com/receipt.jpg" });
@@ -573,7 +573,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.error).toContain("order_id invalido");
     });
 
-    it("Deberia manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       paymentsRepository.getByOrderId.mockResolvedValue({
         id: 1,
         order_id: 1,
@@ -596,7 +596,7 @@ describe("Payments Controller Tests", () => {
   // PATCH /api/payments/order/:order_id/amount
   // ============================================
   describe("PATCH /api/payments/order/:order_id/amount", () => {
-    it("Deberia actualizar el monto reportado exitosamente", async () => {
+    it("should update reported amount successfully", async () => {
       paymentsRepository.getByOrderId.mockResolvedValue({
         id: 1,
         order_id: 1,
@@ -621,7 +621,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.payment).toHaveProperty("amount_reported", 25000);
     });
 
-    it("Deberia devolver error cuando el pago no esta pendiente", async () => {
+    it("should return error when payment is not pending", async () => {
       paymentsRepository.getByOrderId.mockResolvedValue({
         id: 1,
         order_id: 1,
@@ -639,7 +639,7 @@ describe("Payments Controller Tests", () => {
       expect(paymentsRepository.updateAmountReported).not.toHaveBeenCalled();
     });
 
-    it("Deberia devolver 404 cuando no existe el pago", async () => {
+    it("should return 404 when payment does not exist", async () => {
       paymentsRepository.getByOrderId.mockResolvedValue(null);
 
       const res = await request(app)
@@ -650,7 +650,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.error).toContain("Pago no encontrado para esta orden");
     });
 
-    it("Deberia devolver error cuando falta amount_reported", async () => {
+    it("should return error when amount_reported is missing", async () => {
       const res = await request(app)
         .patch("/api/payments/order/1/amount")
         .send({});
@@ -659,7 +659,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.error).toContain("El monto reportado es obligatorio");
     });
 
-    it("Deberia devolver error cuando amount_reported es negativo", async () => {
+    it("should return error when amount_reported is negative", async () => {
       const res = await request(app)
         .patch("/api/payments/order/1/amount")
         .send({ amount_reported: -100 });
@@ -668,7 +668,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.error).toContain("numero valido no negativo");
     });
 
-    it("Deberia devolver error con order_id invalido", async () => {
+    it("should return error with invalid order_id", async () => {
       const res = await request(app)
         .patch("/api/payments/order/abc/amount")
         .send({ amount_reported: 25000 });
@@ -677,7 +677,7 @@ describe("Payments Controller Tests", () => {
       expect(res.body.error).toContain("order_id invalido");
     });
 
-    it("Deberia manejar error de base de datos", async () => {
+    it("should handle database errors", async () => {
       paymentsRepository.getByOrderId.mockResolvedValue({
         id: 1,
         order_id: 1,

--- a/test/products.test.js
+++ b/test/products.test.js
@@ -9,7 +9,7 @@ describe("POST /api/products", () => {
     jest.clearAllMocks();
   });
 
-  it("Debe crear un producto válido", async () => {
+  it("should create a valid product", async () => {
     const mockProduct = {
       id: 1,
       name: "Producto 1",
@@ -33,7 +33,7 @@ describe("POST /api/products", () => {
     expect(res.body.product.price).toBe(100.5);
   });
 
-  it("Debe fallar si falta el nombre", async () => {
+  it("should fail if name is missing", async () => {
     const { ValidationError } = require("../errors/custom-errors");
 
     productService.addProduct.mockRejectedValueOnce(
@@ -49,7 +49,7 @@ describe("POST /api/products", () => {
     expect(res.body.error).toContain("nombre es requerido");
   });
 
-  it("Debe fallar si falta el precio", async () => {
+  it("should fail if price is missing", async () => {
     const { ValidationError } = require("../errors/custom-errors");
 
     productService.addProduct.mockRejectedValueOnce(
@@ -65,7 +65,7 @@ describe("POST /api/products", () => {
     expect(res.body.error).toContain("precio es requerido");
   });
 
-  it("Debe fallar si el precio es negativo", async () => {
+  it("should fail if price is negative", async () => {
     const { ValidationError } = require("../errors/custom-errors");
 
     productService.addProduct.mockRejectedValueOnce(
@@ -82,7 +82,7 @@ describe("POST /api/products", () => {
     expect(res.body.error).toContain("precio no puede ser negativo");
   });
 
-  it("Debe fallar si el nombre es muy corto", async () => {
+  it("should fail if name is too short", async () => {
     const { ValidationError } = require("../errors/custom-errors");
 
     productService.addProduct.mockRejectedValueOnce(
@@ -99,7 +99,7 @@ describe("POST /api/products", () => {
     expect(res.body.error).toContain("nombre debe tener mínimo 2 caracteres");
   });
 
-  it("Debe fallar si el producto ya existe", async () => {
+  it("should fail if product already exists", async () => {
     const { DuplicateError } = require("../errors/custom-errors");
 
     productService.addProduct.mockRejectedValueOnce(
@@ -116,7 +116,7 @@ describe("POST /api/products", () => {
     expect(res.body.error).toContain("Ya existe un producto");
   });
 
-  it("Debe manejar errores de base de datos", async () => {
+  it("should handle database errors", async () => {
     productService.addProduct.mockRejectedValueOnce(new Error("DB error"));
 
     const res = await request(app).post("/api/products").send({
@@ -135,7 +135,7 @@ describe("GET /api/products", () => {
     jest.clearAllMocks();
   });
 
-  it("Debe obtener todos los productos", async () => {
+  it("should get all products", async () => {
     const mockProducts = [
       {
         id: 1,
@@ -162,7 +162,7 @@ describe("GET /api/products", () => {
     expect(res.body[0].name).toBe("Producto 1");
   });
 
-  it("Debe obtener productos con limit y offset", async () => {
+  it("should get products with limit and offset", async () => {
     const mockProducts = [
       {
         id: 1,
@@ -183,7 +183,7 @@ describe("GET /api/products", () => {
     expect(productService.getAllProducts).toHaveBeenCalledWith("10", "0");
   });
 
-  it("Debe manejar errores al obtener productos", async () => {
+  it("should handle errors when fetching products", async () => {
     productService.getAllProducts.mockRejectedValueOnce(new Error("DB error"));
 
     const res = await request(app).get("/api/products");
@@ -198,7 +198,7 @@ describe("GET /api/products/filter", () => {
     jest.clearAllMocks();
   });
 
-  it("Debe filtrar productos por precio mínimo", async () => {
+  it("should filter products by minimum price", async () => {
     const mockProducts = [
       {
         id: 2,
@@ -220,7 +220,7 @@ describe("GET /api/products/filter", () => {
     expect(res.body[0].name).toBe("Producto 2");
   });
 
-  it("Debe filtrar productos por nombre", async () => {
+  it("should filter products by name", async () => {
     const mockProducts = [
       {
         id: 1,
@@ -242,7 +242,7 @@ describe("GET /api/products/filter", () => {
     expect(res.body[0].name).toBe("Producto 1");
   });
 
-  it("Debe filtrar productos por rango de precio", async () => {
+  it("should filter products by price range", async () => {
     const mockProducts = [
       {
         id: 2,
@@ -263,7 +263,7 @@ describe("GET /api/products/filter", () => {
     expect(res.body.length).toBe(1);
   });
 
-  it("Debe filtrar productos por is_active", async () => {
+  it("should filter products by is_active", async () => {
     const mockProducts = [
       {
         id: 1,
@@ -284,7 +284,7 @@ describe("GET /api/products/filter", () => {
     expect(res.body.length).toBe(1);
   });
 
-  it("Debe fallar si no se proporciona ningún filtro", async () => {
+  it("should fail if no filter is provided", async () => {
     const { ValidationError } = require("../errors/custom-errors");
 
     productService.searchProducts.mockRejectedValueOnce(
@@ -297,7 +297,7 @@ describe("GET /api/products/filter", () => {
     expect(res.body.error).toContain("al menos un filtro");
   });
 
-  it("Debe fallar si min_price es mayor que max_price", async () => {
+  it("should fail if min_price is greater than max_price", async () => {
     const { ValidationError } = require("../errors/custom-errors");
 
     productService.searchProducts.mockRejectedValueOnce(
@@ -312,7 +312,7 @@ describe("GET /api/products/filter", () => {
     expect(res.body.error).toContain("precio mínimo no puede ser mayor");
   });
 
-  it("Debe manejar errores al filtrar productos", async () => {
+  it("should handle errors when filtering products", async () => {
     productService.searchProducts.mockRejectedValueOnce(new Error("DB error"));
 
     const res = await request(app)
@@ -329,7 +329,7 @@ describe("GET /api/products/:id", () => {
     jest.clearAllMocks();
   });
 
-  it("Debe obtener un producto por ID", async () => {
+  it("should get a product by ID", async () => {
     const mockProduct = {
       id: 1,
       name: "Producto 1",
@@ -347,7 +347,7 @@ describe("GET /api/products/:id", () => {
     expect(res.body.id).toBe(1);
   });
 
-  it("Debe fallar con ID inválido", async () => {
+  it("should fail with invalid ID", async () => {
     const { ValidationError } = require("../errors/custom-errors");
 
     productService.getProductById.mockRejectedValueOnce(
@@ -360,7 +360,7 @@ describe("GET /api/products/:id", () => {
     expect(res.body.error).toContain("ID inválido");
   });
 
-  it("Debe manejar producto no encontrado", async () => {
+  it("should handle product not found", async () => {
     const { NotFoundError } = require("../errors/custom-errors");
 
     productService.getProductById.mockRejectedValueOnce(
@@ -373,7 +373,7 @@ describe("GET /api/products/:id", () => {
     expect(res.body.error).toBe("Producto no encontrado");
   });
 
-  it("Debe manejar errores de base de datos", async () => {
+  it("should handle database errors", async () => {
     productService.getProductById.mockRejectedValueOnce(new Error("DB error"));
 
     const res = await request(app).get("/api/products/1");
@@ -388,7 +388,7 @@ describe("DELETE /api/products/:id", () => {
     jest.clearAllMocks();
   });
 
-  it("Debe eliminar un producto por ID", async () => {
+  it("should delete a product by ID", async () => {
     const mockProduct = {
       id: 1,
       name: "Producto 1",
@@ -406,7 +406,7 @@ describe("DELETE /api/products/:id", () => {
     expect(res.body.product.id).toBe(1);
   });
 
-  it("Debe fallar con ID inválido", async () => {
+  it("should fail with invalid ID", async () => {
     const { ValidationError } = require("../errors/custom-errors");
 
     productService.hardDelete.mockRejectedValueOnce(
@@ -419,7 +419,7 @@ describe("DELETE /api/products/:id", () => {
     expect(res.body.error).toContain("ID inválido");
   });
 
-  it("Debe manejar producto no encontrado", async () => {
+  it("should handle product not found", async () => {
     const { NotFoundError } = require("../errors/custom-errors");
 
     productService.hardDelete.mockRejectedValueOnce(
@@ -432,7 +432,7 @@ describe("DELETE /api/products/:id", () => {
     expect(res.body.error).toBe("Producto no encontrado");
   });
 
-  it("Debe manejar errores de base de datos", async () => {
+  it("should handle database errors", async () => {
     productService.hardDelete.mockRejectedValueOnce(new Error("DB error"));
 
     const res = await request(app).delete("/api/products/1");
@@ -447,7 +447,7 @@ describe("PUT /api/products/:id", () => {
     jest.clearAllMocks();
   });
 
-  it("Debe actualizar un producto completamente", async () => {
+  it("should fully update a product", async () => {
     const updatedProduct = {
       id: 1,
       name: "Producto Actualizado",
@@ -470,7 +470,7 @@ describe("PUT /api/products/:id", () => {
     expect(res.body.product.name).toBe("Producto Actualizado");
   });
 
-  it("Debe fallar si falta el nombre", async () => {
+  it("should fail if name is missing", async () => {
     const { ValidationError } = require("../errors/custom-errors");
 
     productService.updateProduct.mockRejectedValueOnce(
@@ -486,7 +486,7 @@ describe("PUT /api/products/:id", () => {
     expect(res.body.error).toContain("nombre es requerido");
   });
 
-  it("Debe fallar si falta el precio", async () => {
+  it("should fail if price is missing", async () => {
     const { ValidationError } = require("../errors/custom-errors");
 
     productService.updateProduct.mockRejectedValueOnce(
@@ -502,7 +502,7 @@ describe("PUT /api/products/:id", () => {
     expect(res.body.error).toContain("precio es requerido");
   });
 
-  it("Debe fallar si el producto no existe", async () => {
+  it("should fail if product does not exist", async () => {
     const { NotFoundError } = require("../errors/custom-errors");
 
     productService.updateProduct.mockRejectedValueOnce(
@@ -519,7 +519,7 @@ describe("PUT /api/products/:id", () => {
     expect(res.body.error).toBe("Producto no encontrado");
   });
 
-  it("Debe fallar si el nuevo nombre ya existe", async () => {
+  it("should fail if new name already exists", async () => {
     const { DuplicateError } = require("../errors/custom-errors");
 
     productService.updateProduct.mockRejectedValueOnce(
@@ -536,7 +536,7 @@ describe("PUT /api/products/:id", () => {
     expect(res.body.error).toContain("Ya existe un producto");
   });
 
-  it("Debe manejar errores de base de datos", async () => {
+  it("should handle database errors", async () => {
     productService.updateProduct.mockRejectedValueOnce(new Error("DB error"));
 
     const res = await request(app).put("/api/products/1").send({
@@ -555,7 +555,7 @@ describe("PATCH /api/products/:id", () => {
     jest.clearAllMocks();
   });
 
-  it("Debe actualizar parcialmente solo el precio", async () => {
+  it("should partially update only price", async () => {
     const updatedProduct = {
       id: 1,
       name: "Producto 1",
@@ -575,7 +575,7 @@ describe("PATCH /api/products/:id", () => {
     expect(res.body.product.price).toBe(120.0);
   });
 
-  it("Debe actualizar parcialmente solo el nombre", async () => {
+  it("should partially update only name", async () => {
     const updatedProduct = {
       id: 1,
       name: "Producto Modificado",
@@ -594,7 +594,7 @@ describe("PATCH /api/products/:id", () => {
     expect(res.body.product.name).toBe("Producto Modificado");
   });
 
-  it("Debe fallar si no se proporciona ningún campo", async () => {
+  it("should fail if no field is provided", async () => {
     const { ValidationError } = require("../errors/custom-errors");
 
     productService.updateProductPartial.mockRejectedValueOnce(
@@ -607,7 +607,7 @@ describe("PATCH /api/products/:id", () => {
     expect(res.body.error).toContain("al menos un campo para actualizar");
   });
 
-  it("Debe fallar si el producto no existe", async () => {
+  it("should fail if product does not exist", async () => {
     const { NotFoundError } = require("../errors/custom-errors");
 
     productService.updateProductPartial.mockRejectedValueOnce(
@@ -622,7 +622,7 @@ describe("PATCH /api/products/:id", () => {
     expect(res.body.error).toBe("Producto no encontrado");
   });
 
-  it("Debe fallar si el nuevo nombre ya existe", async () => {
+  it("should fail if new name already exists", async () => {
     const { DuplicateError } = require("../errors/custom-errors");
 
     productService.updateProductPartial.mockRejectedValueOnce(
@@ -637,7 +637,7 @@ describe("PATCH /api/products/:id", () => {
     expect(res.body.error).toContain("Ya existe un producto");
   });
 
-  it("Debe manejar errores de base de datos", async () => {
+  it("should handle database errors", async () => {
     productService.updateProductPartial.mockRejectedValueOnce(
       new Error("DB error")
     );

--- a/test/setupTests.js
+++ b/test/setupTests.js
@@ -9,12 +9,11 @@ jest.mock('../middleware/authenticate', () => {
 });
 
 beforeAll(() => {
-    // Silencia todos los console.error en los tests
+    // Silence all console.error calls in tests
     jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterAll(() => {
-    // Restaura el comportamiento original
+    // Restore original behavior
     console.error.mockRestore();
   });
-  


### PR DESCRIPTION
## Summary

- Add `offset` pagination to `customer-repository`, `addresses-repository`, and `assign-orders-repository` `getAll()` methods, cascading through services and controllers
- Remove unused `BusinessRuleError` import from `assign-orders-service`
- Remove dead commented-out `console.log` from `app.js`
- Inline inconsistent `validateTotal()` logic directly into `collectFieldErrors()` in `orders-service`
- Translate all Spanish `it()`/`describe()` descriptions and inline comments to English across all 9 test files and `setupTests.js`

## Test plan

- [ ] Verify `GET /api/customers?limit=10&offset=5` passes offset correctly to repository
- [ ] Verify `GET /api/addresses?limit=50` works with new signature
- [ ] Verify `GET /api/assign-orders?limit=20&offset=10` applies pagination
- [ ] Run full Jest test suite and confirm all tests pass

https://claude.ai/code/session_01Bp1BTfz7PX1Kzcz63J9Avy